### PR TITLE
build-mbl: outputdir support in build.sh and run.me

### DIFF
--- a/build-mbl/run-me.sh
+++ b/build-mbl/run-me.sh
@@ -115,4 +115,4 @@ docker run --rm -i $flag_tty \
        -e SSH_AUTH_SOCK="$SSH_AUTH_SOCK" \
        -v "$(dirname "$SSH_AUTH_SOCK"):$(dirname "$SSH_AUTH_SOCK")" \
        -v "$workdir":/work "$imagename" \
-       ./build.sh --builddir /work "$@"
+       ./build.sh --builddir /work --outputdir /work/artifacts "$@"


### PR DESCRIPTION
With this change artifacts that we are interested in will be saved in a unique place.
This will facilitate both the developer and the CI system to find artifacts.