### PR TITLE
Update jenkins libraries to use master

### DIFF
--- a/test/ArmJenkinsfile
+++ b/test/ArmJenkinsfile
@@ -1,4 +1,4 @@
-@Library('mbl-jenkins-library@9acbe1e69c264c05f4812ca9f753b3d3b1126f64') _
+@Library('mbl-jenkins-library@master') _
 
 sanityCheckPipeline {
     credentialsId = "fc6db1f7-2a3f-4655-b54a-476bac1194e5"


### PR DESCRIPTION
For the sanity check we can accept to use always the bleeding edge of master

Signed-off-by: Diego Russo <diego.russo@arm.com>