### PR TITLE
Rename imx7s-warp to imx7s-warp-mbl

### DIFF
--- a/build-mbl/build.sh
+++ b/build-mbl/build.sh
@@ -89,7 +89,7 @@ repo_init_atomic ()
   mv "$path-ri" "$path"
 }
 
-all_machines="imx7s-warp raspberrypi3"
+all_machines="imx7s-warp-mbl raspberrypi3"
 
 default_branch="master"
 default_manifest="default.xml"
@@ -489,7 +489,7 @@ while true; do
           mkdir -p "$imagedir/images"
 
           case $machine in
-          imx7s-warp)
+          imx7s-warp-mbl)
             suffixes="manifest tar.xz wic.gz"
             ;;
           raspberrypi3)


### PR DESCRIPTION
This is due to recent changes in meta-mbl repo (https://github.com/ARMmbed/meta-mbl/pull/30)

It solves also https://jira.arm.com/browse/IOTMBL-101