### PR TITLE
imx7-efuse-util: Add initial checkin of eFuse burning utility

### DIFF
--- a/warp7-tools/imx7-efuse-util.py
+++ b/warp7-tools/imx7-efuse-util.py
@@ -235,7 +235,7 @@ def prompt(prompt_string, pass_val):
 def read_fuse_int(fuse_handle):
     """Read fuse setting."""
     chunk = fuse_handle.read(IMX7S_BYTES_PER_FUSE)
-    if chunk == 0:
+    if len(chunk) == 0:
         estr = "Unable to read fuse bank = {} word {}".format(
             IMX7S_BOOT_CFG_BANK, IMX7S_BOOT_CFG0_WORD)
         raise ImxEfuseError(estr, errno.ENODEV)
@@ -319,7 +319,7 @@ def write_srk_fuse(fuse_handle, fuse_map_handle):
     while True:
         # Read input key
         chunk = fuse_map_handle.read(IMX7S_BYTES_PER_FUSE)
-        if chunk == 0:
+        if len(chunk) == 0:
             break
         fuse = string2dword(chunk)
 
@@ -355,7 +355,7 @@ def validate_fuses(fuse_handle, fuse_count):
     while fuse_idx < fuse_count:
         # Read input key
         chunk = fuse_handle.read(IMX7S_BYTES_PER_FUSE)
-        if chunk == 0:
+        if len(chunk) == 0:
             break
         fuse = string2dword(chunk)
 


### PR DESCRIPTION
This utility provides a mechanism for burning One-Time-Programmable (OTP)
fuses on i.MX7Solo and i.MX7Dual processors.

It performs two core functions

1. Viewing the current state of the OTP fuses on i.MX7

   Example printing the state of secure boot fuses:

   imx7-efuse-util.py -s

   Path : /sys/bus/nvmem/devices/imx-ocotp0/nvmem
   Boot Fuse settings
      OCOTP_BOOT_CFG0 = 0x12002820
           FORCE_COLD_BOOT = 0
           BT_FUSE_SEL     = 1
           DIR_BT_DIS      = 0
           SEC_CONFIG      = 1
           Boot Mode       = MMC/eMMC
   Secure fuse keys
   Bank 6
           0x0e250e03
           0x9d560868
           0xa22f48c7
           0x02812e14
   Bank 7
           0xdde453fc
           0x7b42dc98
           0xc2c015d8
           0x733a36f5

2. Programming of the OTP fuses on i.MX7

   Example programming of the SRK fuses:

   imx7-efuse-util.py -k SRK_1_2_3_4_fuse.bin

   Write key values in SRK_1_2_3_4_fuse.bin to SRK fuses =>
   /sys/bus/nvmem/devices/imx-ocotp0/nvmem y/n y

   Key 0 0x0e250e03
   Key 1 0x9d560868
   Key 2 0xa22f48c7
   Key 3 0x02812e14
   Key 4 0xdde453fc
   Key 5 0x7b42dc98
   Key 6 0xc2c015d8
   Key 7 0x733a36f5

   Example locking part into secure boot mode (caution):

   imx7-efuse-util.py -l
   Secure fuse keys
   Bank 6
           0x0e250e03
           0x9d560868
           0xa22f48c7
           0x02812e14
   Bank 7
           0xdde453fc
           0x7b42dc98
           0xc2c015d8
           0x733a36f5
   Lock part into secure-boot mode with above keys ?  y/n y
   Are you REALLY sure ? y/n y
   Key 0 0x0e250e03
   Key 1 0x9d560868
   Key 2 0xa22f48c7
   Key 3 0x02812e14
   Key 4 0xdde453fc
   Key 5 0x7b42dc98
   Key 6 0xc2c015d8
   Key 7 0x733a36f5
   Boot Fuse settings
   OCOTP_BOOT_CFG0 = 0x12002820
           FORCE_COLD_BOOT = 0
           BT_FUSE_SEL     = 1
           DIR_BT_DIS      = 0
           SEC_CONFIG      = 1
           Boot Mode       = MMC/eMMC

Signed-off-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>