### PR TITLE
Rpi3 images are now in wic format

### DIFF
--- a/build-mbl/build.sh
+++ b/build-mbl/build.sh
@@ -571,7 +571,7 @@ while true; do
             suffixes="manifest tar.xz wic.gz"
             ;;
           raspberrypi3)
-            suffixes="rpi-sdimg"
+            suffixes="manifest tar.xz wic.gz"
             ;;
           esac
 


### PR DESCRIPTION
This was implemented by https://github.com/ARMmbed/meta-mbl/pull/39

Signed-off-by: Diego Russo <diego.russo@arm.com>