### PR TITLE
Rename imx7s-warp with imx7s-warp-mbl

### DIFF
--- a/lava/lava-job-definitions/imx7s-warp-mbl/template.yaml
+++ b/lava/lava-job-definitions/imx7s-warp-mbl/template.yaml
@@ -1,4 +1,4 @@
-device_type: imx7s-warp
+device_type: imx7s-warp-mbl
 
 job_name: MBL {{build_tag}}
 timeouts:


### PR DESCRIPTION
imx7s-warp-mbl is the proper machine name used in MBL

Signed-off-by: Diego Russo <diego.russo@arm.com>