### PR TITLE
Ignore .git directory when finding files

### DIFF
--- a/ci/sanity-check/sanity-check.sh
+++ b/ci/sanity-check/sanity-check.sh
@@ -14,7 +14,7 @@ rc=0
 find_files_with_mime()
 {
   local mime="$1"
-  find "$workdir" -type f | \
+  find "$workdir" -type f -not -path "*/\.git/*" | \
     while read -r file_path; do
       if file -i "${file_path}" | grep -q "$mime";
         then printf "%s " "${file_path}";


### PR DESCRIPTION
This is needed because find will traverse anything starting from the
workdir, including .git directory. This directory containes sample hooks
which file command will recognise as shellscripts.
Let's have a conservative approach here in order not to miss anything
important.

Signed-off-by: Diego Russo <diego.russo@arm.com>