### PR TITLE
IOTMBL-947 - Fix boot stage to recognize new login prompts

### DIFF
--- a/lava/lava-job-definitions/imx7s-warp-mbl/template.yaml
+++ b/lava/lava-job-definitions/imx7s-warp-mbl/template.yaml
@@ -26,10 +26,10 @@ actions:
     method: u-boot
     commands: ums
     auto_login:
-      login_prompt: 'imx7s-warp-mbl login:'
+      login_prompt: '(.*) login:'
       username: 'root'
     prompts:
-      - 'root@imx7s-warp-mbl:~#'
+      - 'root@(.*):~#'
     timeout:
       minutes: 50
 - test:


### PR DESCRIPTION
Fixed imx7 template to allow matching the hostname generation introduced by
IOTMBL-827 to enable correctly parsing during the boot stage.