### PR TITLE
Expand paths with ~

### DIFF
--- a/build-mbl/Dockerfile
+++ b/build-mbl/Dockerfile
@@ -60,4 +60,4 @@ RUN mkdir -p /dev/net \
     && chmod 600 /dev/net/tun
 
 # Scripts used to build mbed-linux image
-COPY git-setup.sh ssh-setup.sh build.sh ./
+COPY git-setup.sh ssh-setup.sh shared.sh build.sh ./

--- a/build-mbl/build.sh
+++ b/build-mbl/build.sh
@@ -19,6 +19,10 @@ set -o pipefail
 
 execdir="$(readlink -e "$(dirname "$0")")"
 
+# Include shared functions
+# shellcheck source=shared.sh
+source "$execdir/shared.sh"
+
 write_info()
 {
   printf "info:"
@@ -448,7 +452,7 @@ if [ -z "${builddir:-}" ]; then
   builddir="$(pwd)"
 else
   mkdir -p "$builddir"
-  builddir="$(eval readlink -f "$builddir")"
+  builddir="$(expand_path "$builddir")"
 fi
 
 if [ -z "${images:-}" ]; then
@@ -467,7 +471,7 @@ for machine in $machines; do
 done
 
 if [ -n "${outputdir:-}" ]; then
-  outputdir="$(eval readlink -f "$outputdir")"
+  outputdir="$(expand_path "$outputdir")"
 fi
 
 if empty_stages_p; then
@@ -623,7 +627,7 @@ while true; do
        fi
 
        if [ -n "${downloaddir:-}" ]; then
-         downloaddir=$(eval readlink -f "$downloaddir")
+         downloaddir=$(expand_path "$downloaddir")
          export DL_DIR="$downloaddir"
          export BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE DL_DIR"
        fi

--- a/build-mbl/run-me.sh
+++ b/build-mbl/run-me.sh
@@ -9,6 +9,10 @@ set -u
 
 execdir="$(readlink -e "$(dirname "$0")")"
 
+# Include shared functions
+# shellcheck source=shared.sh
+source "$execdir/shared.sh"
+
 default_builddir="build-mbl-manifest"
 default_imagename="mbl-manifest-env"
 default_containername="mbl-tools-container.$$"
@@ -121,7 +125,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -n "${downloaddir:-}" ]; then
-  downloaddir=$(eval readlink -f "$downloaddir")
+  downloaddir=$(expand_path "$downloaddir")
   if [ ! -e "$downloaddir" ]; then
     printf "error: missing downloaddir %s\n" "$downloaddir" >&2
     exit 3
@@ -129,7 +133,7 @@ if [ -n "${downloaddir:-}" ]; then
 fi
 
 if [ -n "${outputdir:-}" ]; then
-  outputdir=$(eval readlink -f "$outputdir")
+  outputdir=$(expand_path "$outputdir")
   if [ ! -e "$outputdir" ]; then
     printf "error: missing outputdir %s\n" "$outputdir" >&2
     exit 3
@@ -147,7 +151,7 @@ if [ -z "${builddir:-}" ]; then
   builddir="$default_builddir"
 fi
 
-builddir=$(eval readlink -f "$builddir")
+builddir=$(expand_path "$builddir")
 mkdir -p "$builddir"
 
 if [ -n "${inject_mcc_files:-}" ]; then

--- a/build-mbl/shared.sh
+++ b/build-mbl/shared.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Copyright (c) 2018, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+expand_path() {
+    local path=$1
+    # Using shell parameter expansion with the form ${parameter#word}
+    path="${path/#\~/$HOME}"
+    path=$(readlink -f "$path")
+    printf "%s" "$path"
+}

--- a/ci/sanity-check/Dockerfile
+++ b/ci/sanity-check/Dockerfile
@@ -24,4 +24,4 @@ RUN rm -rf /var/lib/apt/lists/*
 # delivery the build products.
 RUN mkdir -m 777 /work
 
-COPY sanity-check.sh tab_finder.py ./
+COPY shared.sh sanity-check.sh tab_finder.py ./

--- a/ci/sanity-check/run-me.sh
+++ b/ci/sanity-check/run-me.sh
@@ -9,6 +9,10 @@ set -u
 
 execdir="$(readlink -e "$(dirname "$0")")"
 
+# Include shared functions
+# shellcheck source=shared.sh
+source "$execdir/shared.sh"
+
 default_imagename="mbl-sanity-check-env"
 default_containername="mbl-sanity-check-container.$$"
 
@@ -93,7 +97,7 @@ done
 if [ -z "${workdir:-}" ]; then
   workdir="$(pwd)"
 fi
-workdir=$(eval readlink -f "$workdir")
+workdir=$(expand_path "$workdir")
 
 docker build -t "$imagename" "$execdir"
 

--- a/ci/sanity-check/sanity-check.sh
+++ b/ci/sanity-check/sanity-check.sh
@@ -9,6 +9,11 @@ set -u
 set -o pipefail
 
 execdir="$(readlink -e "$(dirname "$0")")"
+
+# Include shared functions
+# shellcheck source=shared.sh
+source "$execdir/shared.sh"
+
 rc=0
 
 find_files_with_mime()
@@ -97,7 +102,7 @@ if [ -z "${workdir:-}" ]; then
   workdir="$(pwd)"
 fi
 
-workdir=$(eval readlink -f "$workdir")
+workdir=$(expand_path "$workdir")
 
 # Collect all shell files
 SHELL_FILES=$(find_files_with_mime "text/x-shellscript")
@@ -108,7 +113,7 @@ printf "%s" "$SHELL_FILES" | xargs --no-run-if-empty "$execdir/tab_finder.py" ||
 
 # Run shellcheck on shell files
 printf "Running shellcheck on shell files...\n"
-printf "%s" "$SHELL_FILES" | xargs --no-run-if-empty shellcheck --format=gcc  || rc=1
+printf "%s" "$SHELL_FILES" | xargs --no-run-if-empty shellcheck -x --format=gcc  || rc=1
 
 # Collect all Python files
 PYTHON_FILES=$(find_files_with_mime "text/x-python")

--- a/ci/sanity-check/shared.sh
+++ b/ci/sanity-check/shared.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Copyright (c) 2018, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+expand_path() {
+    local path=$1
+    # Using shell parameter expansion with the form ${parameter#word}
+    path="${path/#\~/$HOME}"
+    path=$(readlink -f "$path")
+    printf "%s" "$path"
+}


### PR DESCRIPTION
This fix a behaviour that getopt has with paths containing `~` (tilde) and long
options that use "=" symbol.
If "`--relativePath ~/path`" is specified, bash will expand `~/path` to
`/home/user/path`.
If "`--relativePath=~/path`" is specified, `~/path` is treated and
it gets to readlink as string.
Unfortunately readlink doesn't do the tilde expansion so we need an extra
function in order to perform the tilde expansion

Fix IOTMBL-943: https://jira.arm.com/browse/IOTMBL-943

Signed-off-by: Diego Russo <diego.russo@arm.com>