### PR TITLE
Check the existence of an SSH agent

### DIFF
--- a/build-mbl/run-me.sh
+++ b/build-mbl/run-me.sh
@@ -159,6 +159,13 @@ if [ -n "${inject_mcc_files:-}" ]; then
   done
 fi
 
+if [ -z "${SSH_AUTH_SOCK+false}" ]; then
+  printf "error: ssh-agent not found.\n" >&2
+  printf "To connect to Github please run an SSH agent and add your SSH key.\n" >&2
+  printf "More info: https://help.github.com/articles/connecting-to-github-with-ssh/\n" >&2
+  exit 4
+fi
+
 docker build -t "$imagename" "$execdir"
 
 if [ -n "${external_manifest:-}" ]; then


### PR DESCRIPTION
The build script fails if an SSH agent (identified with
SSH_AUTH_SOCK variable) is not running.
It doesn't check though if the agent has keys attached. This is caught
later on by the git client when it tries to clone repositories.

This commit addresses IOTMBL-1129.