### PR TITLE
Fix docstring sanity checks

### DIFF
--- a/ci/sanity-check/tab_finder.py
+++ b/ci/sanity-check/tab_finder.py
@@ -37,7 +37,7 @@ def check_tabs(path):
 
 
 def main(args):
-    """Main execution."""
+    """Perform the main execution."""
     parser = argparse.ArgumentParser()
     parser.add_argument("FILE", nargs="*")
     args = parser.parse_args(args)

--- a/lava/submit-to-lava.py
+++ b/lava/submit-to-lava.py
@@ -270,7 +270,7 @@ def _enable_debug_logging(debug=False):
 
 
 def _main(args):
-    """Main execution of the application."""
+    """Perform the main execution of the application."""
     try:
         # Get all the arguments
         args = _parse_arguments(args)

--- a/mbl-release-manager/release_manager.py
+++ b/mbl-release-manager/release_manager.py
@@ -1145,7 +1145,7 @@ class ReleaseManager:
         """
 
         def __call__(self, parser, namespace, values, option_string=None):
-            """Function call operator."""
+            """Override function call operator."""
             file_path = os.path.abspath(values)
             if not os.path.isfile(file_path):
                 raise argparse.ArgumentTypeError(

--- a/mbl-release-manager/setup.py
+++ b/mbl-release-manager/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 
 def read(fname):
-    """Utility function to read the README file."""
+    """Read the content of a file."""
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 


### PR DESCRIPTION
Those sanity checks were caused by the pep257 to pydocstyle update.