### PR TITLE
Use absolute paths in run-me.sh script

### DIFF
--- a/ci/licensing-check/run-me.sh
+++ b/ci/licensing-check/run-me.sh
@@ -95,11 +95,11 @@ if [ -z "${workdir:-}" ]; then
 fi
 workdir=$(readlink -f "$workdir")
 
-cp -r $execdir/../../mbl-licensing-checker $execdir
+cp -r "${execdir}/../../mbl-licensing-checker" "$execdir"
 
 docker build -t "$imagename" "$execdir"
 
-rm -rf $execdir/mbl-licensing-checker
+rm -rf "${execdir}/mbl-licensing-checker"
 
 docker run --rm -i $flag_tty \
        --name "$default_containername" \


### PR DESCRIPTION
This allows the script to be successfully run from any directory.