### PR TITLE
Retry 5 times to flash via uboot-ums

### DIFF
--- a/lava/lava-job-definitions/imx7s-warp-mbl/template.yaml
+++ b/lava/lava-job-definitions/imx7s-warp-mbl/template.yaml
@@ -29,6 +29,7 @@ actions:
 - boot:
     method: u-boot
     commands: ums
+    failure_retry: 5
     auto_login:
       login_prompt: '(.*) login:'
       username: 'root'


### PR DESCRIPTION
uboot-ums is sometime unstable. LAVA will retry to flash 5 times before
failing the job.

Example job: https://lava.mbedcloudtesting.com/scheduler/job/1579

It succeeded at the second attempt :)