### PR TITLE
build-mbl: Remove Docker mounted paths

### DIFF
--- a/build-mbl/Dockerfile
+++ b/build-mbl/Dockerfile
@@ -50,10 +50,6 @@ RUN mkdir -p /usr/local/bin \
     && curl https://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo \
     && chmod a+x "/usr/local/bin/repo"
 
-# The build process needs working space to perform the build and
-# delivery the build products.
-RUN mkdir -m 777 /work
-
 # Make TUN available for qemu
 RUN mkdir -p /dev/net \
     && mknod /dev/net/tun c 10 200 \


### PR DESCRIPTION
When building with Docker and using /work as a mounting point for the
--builddir we end up with broken symlinks outside of the Docker
environment. This patch removes all /work entries and replaces with
$builddir.
It also removes  the /artifacts and /downloads mount points and uses
the "real" ones.

This patch also removes the deprecated --workdir option.

Part of IOTMBL-1638: Improve developer incremental build process.