### PR TITLE
build-mbl/build.sh: Fix "./build.sh: line 163: downloaddir: unbound variable"

### DIFF
--- a/build-mbl/build.sh
+++ b/build-mbl/build.sh
@@ -160,7 +160,7 @@ bitbake_env_setup() {
     export BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE PARALLEL_MAKE BB_NUMBER_THREADS"
   fi
 
-  if [ -n "$downloaddir" ]; then
+  if [ -n "${downloaddir:-}" ]; then
     downloaddir=$(readlink -f "$downloaddir")
     export DL_DIR="$downloaddir"
     export BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE DL_DIR"


### PR DESCRIPTION
When calling build.sh without the downloaddir option we get this
failure message:

./build.sh: Fix line 163: downloaddir: unbound variable