### PR TITLE
0.6 branch: Don't fail a build when optional files are missing

### DIFF
--- a/build-mbl/build.sh
+++ b/build-mbl/build.sh
@@ -335,6 +335,19 @@ create_binary_release()
 
   create_binary_release_readme "$image" "$machine"
 
+  declare -a lic_manifest_files
+  lic_manifest_files+=(license.manifest)
+  lic_manifest_files+=(image_license.manifest)
+
+  # Initramfs manifest files are optional - we don't have an initramfs on some
+  # platforms
+  if [ -e "${artifact_image_dir}/initramfs-license.manifest" ]; then
+    lic_manifest_files+=(initramfs-license.manifest)
+  fi
+  if [ -e "${artifact_image_dir}/initramfs-image_license.manifest" ]; then
+    lic_manifest_files+=(initramfs-image_license.manifest)
+  fi
+
   # If you add files to the binary release archive, please update
   # README.binary_release_template
   tar -c -f "${artifact_image_dir}/binary_release.tar" \
@@ -343,10 +356,7 @@ create_binary_release()
       "${image}-${machine}.wic.bmap" \
     -C "${artifact_image_dir}" \
       source \
-      license.manifest \
-      image_license.manifest \
-      initramfs-license.manifest \
-      initramfs-image_license.manifest \
+      "${lic_manifest_files[@]}" \
       README \
     -C "${artifact_machine_dir}" \
       "licenses.tar$(compress_extension)" \


### PR DESCRIPTION
The initramfs-license.manifest and initramfs-image_license.manifest
files are optional - we don't have a an initramfs (yet) on imx8mmevk-mbl
so only try to add them to a binary release tar if they actually exist.

**Notes**
* This PR is a backport of #150 to the 0.6 branch.

**Jenkins Links**
* http://jenkins.mbed-linux.arm.com/view/jh/job/jh-test/72/ (in progress)