### PR TITLE
build-mbl: Add tmux package to Docker image and set TERM env for interactive mode (#152)

### DIFF
--- a/build-mbl/Dockerfile
+++ b/build-mbl/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     socat \
     texinfo \
+    tmux \
     unzip \
     wget \
     xterm \

--- a/build-mbl/build.sh
+++ b/build-mbl/build.sh
@@ -978,7 +978,7 @@ while true; do
       [[ "$complete_build" == "Y" ]] && push_stages start
     else
       bitbake_env_setup "$machine"
-      exec bash
+      exec env TERM=screen bash
     fi
     ;;
 


### PR DESCRIPTION
In the current Docker image environment there is not seeting for the DISPLAY and access to the X11 server in the host.

To overcome this restriction in the developer interactive shell mode, bitbake can make usage of tmux with the proper TERM env set to screen.

This change was tested with following commands inside the interactive shell:

- bitbake-layers show-appends linux-fslc
- bitbake virtual/kernel -c menuconfig
- bitbake virtual/kernel
- bitbake mbl-image-development
- repo sync

Fixes: IOTMBL-1797: mbl-tools: "bitbake virtual/kernel -c menuconfig" fails in interactive mode

**Notes:**
- This PR is a backport of #152 to the 0.6 branch.