### PR TITLE
Fix timeouts previously reduced/removed for 0.6

### DIFF
--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-32/bcm2837_rpi_3_b_32_base.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-32/bcm2837_rpi_3_b_32_base.yaml
@@ -120,7 +120,7 @@ actions:
 - deploy:
     namespace: lxc
     timeout:
-      minutes: 5
+      minutes: 10
     to: lxc
     os: ubuntu
     packages:

--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-32/helloworld-template.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-32/helloworld-template.yaml
@@ -6,6 +6,8 @@
 
 {% block test %}
 - test:
+    timeout:
+      minutes: 50
     namespace: lxc
     definitions:
     - path: ci/lava/dependencies/install_docker.yaml

--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-32/mbl-core-template.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-32/mbl-core-template.yaml
@@ -5,6 +5,8 @@
 
 {% block test %}
 - test:
+    timeout:
+      minutes: 20
     namespace: target
     definitions:
     - path: lava/tests/mbl-test-dependency.yaml
@@ -25,12 +27,13 @@
       name: mbl-test
       path: inline/mbl-test.yaml
 
-    - path: automated/linux/v4l2/v4l2-compliance.yaml
-      repository: https://git.linaro.org/landing-teams/working/mbl/test-definitions
-      history: false
-      name: v4l2-compliance
-      from: git
-      branch: linaro-mbl
+      # It doesn't make any sense to run this test on RPi3 as there is no video device
+      #    - path: automated/linux/v4l2/v4l2-compliance.yaml
+      #      repository: https://git.linaro.org/landing-teams/working/mbl/test-definitions
+      #      history: false
+      #      name: v4l2-compliance
+      #      from: git
+      #      branch: linaro-mbl
 
       # This test is disabled because it is crashing the DUT:
       # See IOTMBL-1765 and IOTMBL-1766

--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-32/rootfs-update-template.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-32/rootfs-update-template.yaml
@@ -6,6 +6,8 @@
 
 {% block test %}
 - test:
+    timeout:
+      minutes: 20
     namespace: lxc
     definitions:
 

--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/bcm2837_rpi_3_b_plus_32_base.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/bcm2837_rpi_3_b_plus_32_base.yaml
@@ -120,7 +120,7 @@ actions:
 - deploy:
     namespace: lxc
     timeout:
-      minutes: 5
+      minutes: 10
     to: lxc
     os: ubuntu
     packages:

--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/helloworld-template.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/helloworld-template.yaml
@@ -6,6 +6,8 @@
 
 {% block test %}
 - test:
+    timeout:
+      minutes: 50
     namespace: lxc
     definitions:
     - path: ci/lava/dependencies/install_docker.yaml

--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/mbl-core-template.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/mbl-core-template.yaml
@@ -5,6 +5,8 @@
 
 {% block test %}
 - test:
+    timeout:
+      minutes: 20
     namespace: target
     definitions:
     - path: lava/tests/mbl-test-dependency.yaml
@@ -25,12 +27,13 @@
       name: mbl-test
       path: inline/mbl-test.yaml
 
-    - path: automated/linux/v4l2/v4l2-compliance.yaml
-      repository: https://git.linaro.org/landing-teams/working/mbl/test-definitions
-      history: false
-      name: v4l2-compliance
-      from: git
-      branch: linaro-mbl
+      # It doesn't make any sense to run this test on RPi3 as there is no video device
+      #    - path: automated/linux/v4l2/v4l2-compliance.yaml
+      #      repository: https://git.linaro.org/landing-teams/working/mbl/test-definitions
+      #      history: false
+      #      name: v4l2-compliance
+      #      from: git
+      #      branch: linaro-mbl
 
       # This test is disabled because it is crashing the DUT:
       # See IOTMBL-1765 and IOTMBL-1766

--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/rootfs-update-template.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/rootfs-update-template.yaml
@@ -6,6 +6,8 @@
 
 {% block test %}
 - test:
+    timeout:
+      minutes: 20
     namespace: lxc
     definitions:
 

--- a/lava/lava-job-definitions/imx7s-warp-mbl/helloworld-template.yaml
+++ b/lava/lava-job-definitions/imx7s-warp-mbl/helloworld-template.yaml
@@ -6,6 +6,8 @@
 
 {% block test %}
 - test:
+    timeout:
+      minutes: 50
     namespace: lxc
     definitions:
     - path: ci/lava/dependencies/install_docker.yaml

--- a/lava/lava-job-definitions/imx7s-warp-mbl/imx7s_warp_mbl_base.yaml
+++ b/lava/lava-job-definitions/imx7s-warp-mbl/imx7s_warp_mbl_base.yaml
@@ -52,13 +52,13 @@ actions:
     prompts:
       - "root@mbed-linux-os(.*):~#"
     timeout:
-      minutes: 5
+      minutes: 10
 
 {% if lxc_creation %}
 - deploy:
     namespace: lxc
     timeout:
-      minutes: 5
+      minutes: 10
     to: lxc
     os: ubuntu
     packages:

--- a/lava/lava-job-definitions/imx7s-warp-mbl/mbl-core-template.yaml
+++ b/lava/lava-job-definitions/imx7s-warp-mbl/mbl-core-template.yaml
@@ -5,6 +5,8 @@
 
 {% block test %}
 - test:
+    timeout:
+      minutes: 20
     namespace: target
     definitions:
     - path: lava/tests/mbl-test-dependency.yaml

--- a/lava/lava-job-definitions/imx7s-warp-mbl/rootfs-update-template.yaml
+++ b/lava/lava-job-definitions/imx7s-warp-mbl/rootfs-update-template.yaml
@@ -6,6 +6,8 @@
 
 {% block test %}
 - test:
+    timeout:
+      minutes: 20
     namespace: lxc
     definitions:
 


### PR DESCRIPTION
We've been too strict in setting timeouts and this should fix the issue
of failing jobs because of timeouts.
It removes also the v4l2-compliance test for RPi3 devices.