### PR TITLE
Upgrade kernel for first stage RPi3 deployment on LAVA

### DIFF
--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-32/bcm2837_rpi_3_b_32_base.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-32/bcm2837_rpi_3_b_32_base.yaml
@@ -47,14 +47,14 @@ actions:
       minutes: 5
     to: tftp
     kernel:
-      url: http://artifactory-proxy.mbed-linux.arm.com/artifactory/isg-mbed-linux/lava/RPI3/mbl-os-0.5.37/zImage
+      url: http://artifactory-proxy.mbed-linux.arm.com/artifactory/isg-mbed-linux/lava/RPI3/mbl-os-0.5.177/zImage
       type: zimage
     nfsrootfs:
       url: http://images.validation.linaro.org/snapshots.linaro.org/openembedded/mbl/linaro-pyro-pinned/raspberrypi3/31/rpb/rpb-console-image-raspberrypi3-20171109202053-31.rootfs.tar.xz
       compression: xz
     os: oe
     dtb:
-      url: http://artifactory-proxy.mbed-linux.arm.com/artifactory/isg-mbed-linux/lava/RPI3/mbl-os-0.5.37/bcm2710-rpi-3-b.dtb
+      url: http://artifactory-proxy.mbed-linux.arm.com/artifactory/isg-mbed-linux/lava/RPI3/mbl-os-0.5.177/bcm2710-rpi-3-b.dtb
     preseed:
       url: {{ image_url }}
 # We firstly boot on the NFS

--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/bcm2837_rpi_3_b_plus_32_base.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/bcm2837_rpi_3_b_plus_32_base.yaml
@@ -47,14 +47,14 @@ actions:
       minutes: 5
     to: tftp
     kernel:
-      url: http://artifactory-proxy.mbed-linux.arm.com/artifactory/isg-mbed-linux/lava/RPI3/mbl-os-0.5.37/zImage
+      url: http://artifactory-proxy.mbed-linux.arm.com/artifactory/isg-mbed-linux/lava/RPI3/mbl-os-0.5.177/zImage
       type: zimage
     nfsrootfs:
       url: http://images.validation.linaro.org/snapshots.linaro.org/openembedded/mbl/linaro-pyro-pinned/raspberrypi3/31/rpb/rpb-console-image-raspberrypi3-20171109202053-31.rootfs.tar.xz
       compression: xz
     os: oe
     dtb:
-      url: http://artifactory-proxy.mbed-linux.arm.com/artifactory/isg-mbed-linux/lava/RPI3/mbl-os-0.5.37/bcm2710-rpi-3-b-plus.dtb
+      url: http://artifactory-proxy.mbed-linux.arm.com/artifactory/isg-mbed-linux/lava/RPI3/mbl-os-0.5.177/bcm2710-rpi-3-b-plus.dtb
     preseed:
       url: {{ image_url }}
 # We firstly boot on the NFS


### PR DESCRIPTION
Due to a bug in the kernel driver for the ethernet interface the
deployment was stuck on errors produced by the driver.
The build mbl-os-0.5.177 has a new kernel that fixes this issue.