### PR TITLE
LAVA: Specify arch of the DUT to build the correct helloworld app bin

### DIFF
--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-32/helloworld-template.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-32/helloworld-template.yaml
@@ -23,6 +23,8 @@
       from: git
       history: False
       branch: {{ mbl_branch }}
+      parameters:
+        arm_arch: armv7
 
     - path: ci/lava/dependencies/mbl-install-mbl-cli.yaml
       repository: https://github.com/ARMmbed/mbl-cli.git

--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/helloworld-template.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/helloworld-template.yaml
@@ -23,6 +23,8 @@
       from: git
       history: False
       branch: {{ mbl_branch }}
+      parameters:
+        arm_arch: armv7
 
     - path: ci/lava/dependencies/mbl-install-mbl-cli.yaml
       repository: https://github.com/ARMmbed/mbl-cli.git

--- a/lava/lava-job-definitions/imx7s-warp-mbl/helloworld-template.yaml
+++ b/lava/lava-job-definitions/imx7s-warp-mbl/helloworld-template.yaml
@@ -23,6 +23,8 @@
       from: git
       history: False
       branch: {{ mbl_branch }}
+      parameters:
+        arm_arch: armv7
 
     - path: ci/lava/dependencies/mbl-install-mbl-cli.yaml
       repository: https://github.com/ARMmbed/mbl-cli.git


### PR DESCRIPTION
[For IOTMBL-1813 NXP 8M Mini EVK application status does not change to
RUNNING](https://jira.arm.com/browse/IOTMBL-1813)

The shell script requires the architecture of the DUT in order to select
the appropriate cross-compiler to build the user-sample-app-package
binary.