### PR TITLE
Increase RootFS timeout to 30 minutes

### DIFF
--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-32/rootfs-update-template.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-32/rootfs-update-template.yaml
@@ -7,7 +7,7 @@
 {% block test %}
 - test:
     timeout:
-      minutes: 20
+      minutes: 30
     namespace: lxc
     definitions:
     - path: ci/lava/tests/mbl-avahi-discovery-test.yaml

--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/rootfs-update-template.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/rootfs-update-template.yaml
@@ -7,7 +7,7 @@
 {% block test %}
 - test:
     timeout:
-      minutes: 20
+      minutes: 30
     namespace: lxc
     definitions:
     - path: ci/lava/tests/mbl-avahi-discovery-test.yaml

--- a/lava/lava-job-definitions/imx7s-warp-mbl/rootfs-update-template.yaml
+++ b/lava/lava-job-definitions/imx7s-warp-mbl/rootfs-update-template.yaml
@@ -7,12 +7,12 @@
 {% block test %}
 - test:
     timeout:
-      minutes: 20
+      minutes: 30
     namespace: lxc
     definitions:
     - path: ci/lava/tests/mbl-avahi-discovery-test.yaml
       repository: https://github.com/ARMmbed/mbl-core.git
-      name: run_avahi_discovery_pre_rootfs_test 
+      name: run_avahi_discovery_pre_rootfs_test
       from: git
       history: False
       branch: {{ mbl_branch }}
@@ -63,7 +63,7 @@
 
     - path: ci/lava/tests/mbl-avahi-discovery-test.yaml
       repository: https://github.com/ARMmbed/mbl-core.git
-      name: run_avahi_discovery_post_rootfs_test 
+      name: run_avahi_discovery_post_rootfs_test
       from: git
       history: False
       branch: {{ mbl_branch }}


### PR DESCRIPTION
Sometimes the RootFS job taks more than 20 minutes to run. This depends
on the load that the slave has and the jobs running on the LXC container
could take more time than expected.