### PR TITLE
Check for successful setup-environment

### DIFF
--- a/build-mbl/build.sh
+++ b/build-mbl/build.sh
@@ -163,6 +163,10 @@ bitbake_env_setup() {
   set +e
   # shellcheck disable=SC1091
   MACHINE="$machine" DISTRO="$distro" . setup-environment "build-mbl"
+  # shellcheck disable=SC2181
+  if [ $? -ne 0 ]; then
+      exit 1
+  fi
   set -u
   set -e
 
@@ -834,6 +838,10 @@ while true; do
        set +e
        # shellcheck disable=SC1091
        MACHINE="$machine" DISTRO="$distro" . setup-environment "build-mbl"
+       # shellcheck disable=SC2181
+       if [ $? -ne 0 ]; then
+           exit 1
+       fi
        set -u
        set -e
       )


### PR DESCRIPTION
Added checking that the setup-environment is successful, to catch when EULA has not been accepted or other failures.