### PR TITLE
IOTMBL-1567 Add MBL CLI Basic Commands Test

### DIFF
--- a/ci/run-tests/Dockerfile
+++ b/ci/run-tests/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /work
 # We expect the python package contains a requirements.txt to install development dependencies.
 RUN pip3 install pytest && pip3 install -r requirements.txt
 
-CMD [ "pytest", "--junit-xml", "report" ]
+CMD [ "pytest", "tests/unit", "--junit-xml", "report" ]

--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-32/mbl-cli-basic-commands-template.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-32/mbl-cli-basic-commands-template.yaml
@@ -1,0 +1,26 @@
+{% extends "bcm2837_rpi_3_b_32_base.yaml" %}
+
+{% set job_name = "MBL CLI Basic Commands" %}
+{% set lxc_creation = true %}
+{% set lxc_name = "mbl-cli-lxc" %}
+
+{% block test %}
+- test:
+    timeout:
+      minutes: 50
+    namespace: lxc
+    definitions:
+    - path: ci/lava/dependencies/mbl-install-mbl-cli.yaml
+      repository: https://github.com/ARMmbed/mbl-cli.git
+      name: install_mbl_cli
+      from: git
+      history: False
+      branch: {{ mbl_branch }}
+
+    - path: ci/lava/tests/mbl_cli_basic_commands.yaml
+      repository: https://github.com/ARMmbed/mbl-cli.git
+      name: run_mbl_cli_basic_commands
+      from: git
+      history: False
+      branch: {{ mbl_branch }}
+{% endblock test %}

--- a/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/mbl-cli-basic-commands-template.yaml
+++ b/lava/lava-job-definitions/bcm2837-rpi-3-b-plus-32/mbl-cli-basic-commands-template.yaml
@@ -1,0 +1,26 @@
+{% extends "bcm2837_rpi_3_b_plus_32_base.yaml" %}
+
+{% set job_name = "MBL CLI Basic Commands" %}
+{% set lxc_creation = true %}
+{% set lxc_name = "mbl-cli-lxc" %}
+
+{% block test %}
+- test:
+    timeout:
+      minutes: 50
+    namespace: lxc
+    definitions:
+    - path: ci/lava/dependencies/mbl-install-mbl-cli.yaml
+      repository: https://github.com/ARMmbed/mbl-cli.git
+      name: install_mbl_cli
+      from: git
+      history: False
+      branch: {{ mbl_branch }}
+
+    - path: ci/lava/tests/mbl_cli_basic_commands.yaml
+      repository: https://github.com/ARMmbed/mbl-cli.git
+      name: run_mbl_cli_basic_commands
+      from: git
+      history: False
+      branch: {{ mbl_branch }}
+{% endblock test %}

--- a/lava/lava-job-definitions/imx7s-warp-mbl/mbl-cli-basic-commands-template.yaml
+++ b/lava/lava-job-definitions/imx7s-warp-mbl/mbl-cli-basic-commands-template.yaml
@@ -1,0 +1,26 @@
+{% extends "imx7s_warp_mbl_base.yaml" %}
+
+{% set job_name = "MBL CLI Basic Commands" %}
+{% set lxc_creation = true %}
+{% set lxc_name = "mbl-cli-lxc" %}
+
+{% block test %}
+- test:
+    timeout:
+      minutes: 50
+    namespace: lxc
+    definitions:
+    - path: ci/lava/dependencies/mbl-install-mbl-cli.yaml
+      repository: https://github.com/ARMmbed/mbl-cli.git
+      name: install_mbl_cli
+      from: git
+      history: False
+      branch: {{ mbl_branch }}
+
+    - path: ci/lava/tests/mbl_cli_basic_commands.yaml
+      repository: https://github.com/ARMmbed/mbl-cli.git
+      name: run_mbl_cli_basic_commands
+      from: git
+      history: False
+      branch: {{ mbl_branch }}
+{% endblock test %}


### PR DESCRIPTION
Add test specifications for the MBL-CLI basic commands test job.

Includes a tweak to the MBL CLI unit test Docker file as the unit tests have been moved to a sub-folder.

LAVA: http://lava.mbedcloudtesting.com/scheduler/job/3773