### PR TITLE
Point pytest at the MBL CLI unit test directory

### DIFF
--- a/ci/run-tests/Dockerfile
+++ b/ci/run-tests/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /work
 # We expect the python package contains a requirements.txt to install development dependencies.
 RUN pip3 install pytest && pip3 install -r requirements.txt
 
-CMD [ "pytest", "--junit-xml", "report" ]
+CMD [ "pytest", "tests/unit", "--junit-xml", "report" ]


### PR DESCRIPTION
The directory structure of the MBL CLI tests has changed. Two subdirs have been added: "unit" and "integration". Point pytest at the unit test directory, so it doesn't try to run the integration tests on every commit to the MBL CLI repo.