### PR TITLE
Build HelloWorld for armv7 architecture.

### DIFF
--- a/lava/lava-job-definitions/shared/tests/build-helloworld.yaml
+++ b/lava/lava-job-definitions/shared/tests/build-helloworld.yaml
@@ -5,4 +5,4 @@
   history: False
   branch: {{ mbl_branch }}
   parameters:
-     arm_arch: {{ device_type }}
+     arm_arch: armv7


### PR DESCRIPTION
Changed the template to pass the architecture (armv7) rather than the
device type.