### PR TITLE
Change pip installation command in MBL CLI Dockerfile

### DIFF
--- a/ci/run-tests/Dockerfile
+++ b/ci/run-tests/Dockerfile
@@ -4,7 +4,7 @@ ADD . /work
 
 WORKDIR /work
 
-# We expect the python package contains a requirements.txt to install development dependencies.
-RUN pip3 install pytest && pip3 install -r requirements.txt
+# We expect the python package contains a setup.py.
+RUN pip3 install pytest && pip3 install .
 
 CMD [ "pytest", "tests/unit", "--junit-xml", "report" ]


### PR DESCRIPTION
After changing the dependency handling in MBL CLI, the unit test set-up needs to be updated.

Install MBL CLI using setup.py instead of requirements.txt.