### PR TITLE
runtests-Dockerfile: Point pytest at unit test directory

### DIFF
--- a/ci/run-tests/Dockerfile
+++ b/ci/run-tests/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /work
 # We expect the python package contains a setup.py.
 RUN pip3 install pytest && pip3 install .
 
-CMD [ "pytest", "--junit-xml", "report" ]
+CMD [ "pytest", "tests/unit", "--junit-xml", "report" ]


### PR DESCRIPTION
MBL CLI tests have been moved to a 'unit' subfolder. Point pytest to it.