### PR TITLE
Remove unused arguments

### DIFF
--- a/lava/lava-job-definitions/shared/templates/base.yaml
+++ b/lava/lava-job-definitions/shared/templates/base.yaml
@@ -49,15 +49,12 @@ protocols:
     packages:
     - avahi-utils
     - python3-venv
-    prompts:
-      - "root@{{ lxc_name }}-(.*):/#"
 
 - boot:
     namespace: lxc
     method: lxc
     timeout:
       minutes: 5
-    failure-retry: 3
     prompts:
       - "root@{{ lxc_name }}-(.*):/#"
 {% endif %}


### PR DESCRIPTION
With LAVA 2019.04 we have a better validation when submitting jobs.
The lines removed by the commit raised warnings when submitting jobs via
the web page