### PR TITLE
Don't power cycle with minimal boot on RootFS update

### DIFF
--- a/lava/lava-job-definitions/testplans/rootfs-update-template.yaml
+++ b/lava/lava-job-definitions/testplans/rootfs-update-template.yaml
@@ -22,6 +22,8 @@
 - boot:
     namespace: target
     method: minimal
+    # We don't power cycle because the rootfs update has rebooted the DUT
+    reset: false
     auto_login:
         login_prompt: 'lava-mbed-linux-os-(.*) login:'
         username: 'root'


### PR DESCRIPTION
The RootFS update (via Pelion or mbl-cli) does reboot the DUT already
so we don't need to power cycle it.