### PR TITLE
Save artifacts after building Pelion Edge

### DIFF
--- a/build-mbl/build-pelion-os-edge.py
+++ b/build-mbl/build-pelion-os-edge.py
@@ -286,7 +286,7 @@ def main():
         _inject_mcc(args.builddir, path)
 
     _set_up_bitbake_ssh(args.builddir)
-    # _build(args.builddir)
+    _build(args.builddir)
     _save_artifacts(args.builddir, args.outputdir)
 
 


### PR DESCRIPTION
Build artifacts are saved into the output directory. Those include:
* the deploy directory (except uncompressed image)
* license information
* the manifest file

Commit related to IOTMBL-2101