### PR TITLE
license-report: Don't raise exceptions and emit a warning.

### DIFF
--- a/build-mbl/license-report/license_diff_report.py
+++ b/build-mbl/license-report/license_diff_report.py
@@ -393,7 +393,6 @@ def _main():
             if args.html:
                 make_html(sorted_report, image, machines, args.html)
     except Exception as err:
-        raise
         # Don't raise to the interpreter level as this script shouldn't fail
         # even if the license report creation fails.
         print(err, file=sys.stderr)


### PR DESCRIPTION
Don't raise exceptions to the interpreter level in
license_diff_report.py. The build shouldn't fail if the license report
fails.