### PR TITLE
build.sh: Exclude qca firmware binary for release

### DIFF
--- a/build-mbl/build.sh
+++ b/build-mbl/build.sh
@@ -301,7 +301,7 @@ create_binary_release_readme()
     "${execdir}/README.binary_release_template" > "${artifact_image_dir}/README"
 
   case "$machine" in
-    imx8mmevk-mbl|imx7d-pico-mbl)
+    imx8mmevk-mbl)
       cat "${execdir}/Licensing_and_Acknowledgment.template_nxp" >> "${artifact_image_dir}/README"
       ;;
     *)


### PR DESCRIPTION
Add a flag to exclude qca9377 WiFi firmware binary for release
because the license constraint.

Signed-off-by: Jun Nie <jun.nie@linaro.org>

should be merged together with
https://github.com/ARMmbed/meta-mbl/pull/559
https://github.com/ARMmbed/mbl-config/pull/48