### PR TITLE
build-mbl/build.sh: Use Global replacement for bh_path

### DIFF
--- a/build-mbl/build.sh
+++ b/build-mbl/build.sh
@@ -935,7 +935,7 @@ while true; do
 
           # Dot graphs
           mkdir -p "$imagedir/dot/"
-          bh_path="$builddir/machine-$machine/mbl-manifest/build-mbl/buildhistory/images/${machine/-/_}/glibc/$image"
+          bh_path="$builddir/machine-$machine/mbl-manifest/build-mbl/buildhistory/images/${machine//-/_}/glibc/$image"
           for path in "$bh_path/"*.dot; do
             if [ -e "$path" ]; then
               write_info "save artifact %s\n" "$(basename "$path")"


### PR DESCRIPTION
MBL machines names have one or more "-" and for the bh_path we
substitute them to "_" in to collect the build info and dependency
graph files.

Tested on local builds for imx7d-pico-mbl and imx8mmevk-mbl machines and the files under "info" and "dot" folders are being copied as expected.