### PR TITLE
Increase uboot timeout to 15 minutes

### DIFF
--- a/lava/lava-job-definitions/shared/templates/uboot-ums-deploy-boot.yaml
+++ b/lava/lava-job-definitions/shared/templates/uboot-ums-deploy-boot.yaml
@@ -19,4 +19,4 @@ actions:
     prompts:
       - "root@mbed-linux-os(.*):~#"
     timeout:
-      minutes: 10
+      minutes: 15


### PR DESCRIPTION
This is needed because imx8 seems to take more time to flash the image.