### PR TITLE
Add mechanism to add tags to LAVA pipelines

### DIFF
--- a/lava/lava-job-definitions/shared/templates/base.yaml
+++ b/lava/lava-job-definitions/shared/templates/base.yaml
@@ -7,6 +7,13 @@ device_type: "{{ device_type }}"
 
 job_name: "{{ build_tag }} - {{ job_name }}"
 
+{% if tags[device_type] %}
+tags:
+{% for tag in tags[device_type] %}
+- {{ tag }}
+{% endfor %}
+{% endif %}
+
 {% set venv_name = "/tmp/venv" %}
 
 metadata:

--- a/lava/lava-job-definitions/testplans/wifi-access.yaml
+++ b/lava/lava-job-definitions/testplans/wifi-access.yaml
@@ -4,6 +4,8 @@
 {% set lxc_creation = true %}
 {% set lxc_name = "wifi-access-lxc" %}
 
+{% set _ = tags.update({"imx7d-pico-mbl": ["external_antenna"]}) %}
+
 {% block testplan %}
 - test:
     timeout:

--- a/lava/lava-job-definitions/testplans/wired-and-wifi.yaml
+++ b/lava/lava-job-definitions/testplans/wired-and-wifi.yaml
@@ -4,6 +4,8 @@
 {% set lxc_creation = true %}
 {% set lxc_name = "wired-and-wifi-test-lxc" %}
 
+{% set _ = tags.update({"imx7d-pico-mbl": ["external_antenna"]}) %}
+
 {% block testplan %}
 - test:
     timeout:

--- a/lava/submit-to-lava.py
+++ b/lava/submit-to-lava.py
@@ -71,6 +71,7 @@ class LAVATemplates(object):
                 notify_user=notify_user,
                 notify_emails=notify_emails,
                 device_type=device_type,
+                tags={},
             )
             lava_jobs.append(lava_job)
             if self.dry_run:


### PR DESCRIPTION
This is needed because we have only one antenna installed on
imx7d-pico-mbl boards and we need to run wifi jobs on the board tagged with
"external_antenna"