### PR TITLE
Add testplan for psa-arch-tests

### DIFF
--- a/lava/lava-job-definitions/testplans/psa-arch-tests.yaml
+++ b/lava/lava-job-definitions/testplans/psa-arch-tests.yaml
@@ -1,0 +1,28 @@
+{% extends "shared/templates/base.yaml" %}
+
+{% set job_name = "PSA architecture tests" %}
+{% set lxc_creation = true %}
+{% set lxc_name = "psa-arch-tests-lxc" %}
+
+{% block testplan %}
+- test:
+    timeout:
+      minutes: 3
+    namespace: lxc
+    definitions:
+
+    {{ macros.install_mbl_cli(venv_name) | indent }}
+
+    - path: ci/lava/tests/psa-arch-tests.yaml
+      repository: https://github.com/ARMmbed/mbl-core.git
+      name: psa-arch-tests
+      from: git
+      history: False
+      branch: "{{ mbl_branch }}"
+      {% if "mbl-core" in mbl_revisions %}
+      revision: {{ mbl_revisions["mbl-core"] }}
+      {% endif %}
+      parameters:
+          virtual_env: "{{ venv_name }}"
+{% endblock testplan %}
+

--- a/lava/lava-job-definitions/testplans/psa-arch-tests.yaml
+++ b/lava/lava-job-definitions/testplans/psa-arch-tests.yaml
@@ -7,7 +7,7 @@
 {% block testplan %}
 - test:
     timeout:
-      minutes: 3
+      minutes: 10
     namespace: lxc
     definitions:
 


### PR DESCRIPTION
For IOTMBL-2147: Create recipe for psa-arch-tests

**Related PRs**
* https://github.com/ARMmbed/meta-mbl/pull/598 (to add psa-arch-tests recipe).
* https://github.com/ARMmbed/mbl-core/pull/194 (to add a script to run the tests from a dev host).
* https://github.com/ARMmbed/meta-mbl/pull/601 (to update the mbl-core SRCREV after https://github.com/ARMmbed/mbl-core/pull/194 is merged).
* https://github.com/ARMmbed/mbl-jenkins/pull/111 (to add the new test plan to the warrior-dev Jenkins build). 

**Jenkins and Lava links**
* See https://github.com/ARMmbed/meta-mbl/pull/598