### PR TITLE
 build-mbl: Add extra --mcc-destdir parameter

### DIFF
--- a/build-mbl/build.sh
+++ b/build-mbl/build.sh
@@ -712,9 +712,14 @@ if [ "${flag_binary_release}" -eq 1 ]; then
     fi
 fi
 
-if [ -n "${mcc_destdir:-}" ] && [ -z "${inject_mcc_files:-}" ]; then
-  printf "error: --mcc-destdir requires at least one --inject-mcc parameter.\n" >&2
-  exit 3
+if [ -n "${mcc_destdir:-}" ]; then
+  if [ -z "${inject_mcc_files:-}" ]; then
+      printf "error: --mcc-destdir requires at least one --inject-mcc parameter.\n" >&2
+      exit 3
+  fi
+  mcc_final_destdir="layers/$mcc_destdir"
+else
+  mcc_final_destdir="build-mbl"
 fi
 
 if empty_stages_p; then
@@ -857,12 +862,7 @@ while true; do
       for machine in $machines; do
         for file in $inject_mcc_files; do
           base="$(basename "$file")"
-          if [ -z "${mcc_destdir:-}" ]; then
-              mcc_final_destdir="$builddir/machine-$machine/mbl-manifest/build-mbl"
-          else
-              mcc_final_destdir="$builddir/machine-$machine/mbl-manifest/layers/$mcc_destdir"
-          fi
-          cp "$file" "$mcc_final_destdir/$base"
+          cp "$file" "$builddir/machine-$machine/mbl-manifest/$mcc_final_destdir/$base"
         done
       done
     fi

--- a/build-mbl/build.sh
+++ b/build-mbl/build.sh
@@ -97,6 +97,8 @@ default_distro="mbl"
 default_images="mbl-image-development"
 default_accept_eula_machines=""
 default_lic_cmp_build_tag=""
+default_mcc_destdir="build-mbl"
+
 # Test if a machine name appears in the all_machines list.
 #
 
@@ -717,9 +719,7 @@ if [ -n "${mcc_destdir:-}" ]; then
       printf "error: --mcc-destdir requires at least one --inject-mcc parameter.\n" >&2
       exit 3
   fi
-  mcc_final_destdir="layers/$mcc_destdir"
-else
-  mcc_final_destdir="build-mbl"
+  default_mcc_destdir="layers/$mcc_destdir"
 fi
 
 if empty_stages_p; then
@@ -862,7 +862,7 @@ while true; do
       for machine in $machines; do
         for file in $inject_mcc_files; do
           base="$(basename "$file")"
-          cp "$file" "$builddir/machine-$machine/mbl-manifest/$mcc_final_destdir/$base"
+          cp "$file" "$builddir/machine-$machine/mbl-manifest/$default_mcc_destdir/$base"
         done
       done
     fi

--- a/build-mbl/build.sh
+++ b/build-mbl/build.sh
@@ -866,7 +866,6 @@ while true; do
         done
       done
     fi
-    exit
     push_stages build
     ;;
 

--- a/build-mbl/build.sh
+++ b/build-mbl/build.sh
@@ -464,7 +464,7 @@ OPTIONAL parameters:
                         to be injected into a build.  This is a temporary
                         mechanism to inject development keys. Mandatory if passing
                         --mcc-destdir parameter.
-  --mcc-destdir PATH    Relative directory from bitbake \${TOPDIR} to where the file(s)
+  --mcc-destdir PATH    Relative directory from "layers" dir to where the file(s)
                         passed with --inject-mcc should be copied to.
   --licenses            Collect extra build license info. Default disabled.
   --manifest MANIFEST   Name the manifest file. Default ${default_manifest}.
@@ -858,12 +858,15 @@ while true; do
         for file in $inject_mcc_files; do
           base="$(basename "$file")"
           if [ -z "${mcc_destdir:-}" ]; then
-              mcc_destdir=""
+              mcc_final_destdir="$builddir/machine-$machine/mbl-manifest/build-mbl"
+          else
+              mcc_final_destdir="$builddir/machine-$machine/mbl-manifest/layers/$mcc_destdir"
           fi
-          cp "$file" "$builddir/machine-$machine/mbl-manifest/build-mbl/$mcc_destdir/$base"
+          cp "$file" "$mcc_final_destdir/$base"
         done
       done
     fi
+    exit
     push_stages build
     ;;
 

--- a/build-mbl/build.sh
+++ b/build-mbl/build.sh
@@ -498,6 +498,7 @@ EOF
 
 url="$default_url"
 distro="$default_distro"
+mcc_final_destdir="$default_mcc_destdir"
 flag_compress=1
 flag_archiver=""
 flag_licenses=0
@@ -719,7 +720,7 @@ if [ -n "${mcc_destdir:-}" ]; then
       printf "error: --mcc-destdir requires at least one --inject-mcc parameter.\n" >&2
       exit 3
   fi
-  default_mcc_destdir="layers/$mcc_destdir"
+  mcc_final_destdir="layers/$mcc_destdir"
 fi
 
 if empty_stages_p; then
@@ -862,7 +863,7 @@ while true; do
       for machine in $machines; do
         for file in $inject_mcc_files; do
           base="$(basename "$file")"
-          cp "$file" "$builddir/machine-$machine/mbl-manifest/$default_mcc_destdir/$base"
+          cp "$file" "$builddir/machine-$machine/mbl-manifest/$mcc_final_destdir/$base"
         done
       done
     fi

--- a/build-mbl/run-me.sh
+++ b/build-mbl/run-me.sh
@@ -40,7 +40,10 @@ OPTIONAL parameters:
   --image-name NAME     Specify the docker image name to build. Default ${default_imagename}.
   --inject-mcc PATH     Add a file to the list of mbed cloud client files
                         to be injected into a build.  This is a temporary
-                        mechanism to inject development keys.
+                        mechanism to inject development keys.  Mandatory if passing
+                        --mcc-destdir parameter.
+  --mcc-destdir PATH    Relative directory from bitbake ${TOPDIR} to where the file(s)
+                        passed with --inject-mcc should be copied to.
   --mbl-tools-version STRING
                         Specify the version of mbl-tools that this script comes
                         from. This is written to buildinfo.txt in the output
@@ -64,7 +67,7 @@ flag_tty="-t"
 # record of how this script was invoked
 command_line="$(printf '%q ' "$0" "$@")"
 
-args=$(getopt -o+ho:x -l builddir:,downloaddir:,external-manifest:,help,image-name:,inject-mcc:,mbl-tools-version:,outputdir:,tty,no-tty -n "$(basename "$0")" -- "$@")
+args=$(getopt -o+ho:x -l builddir:,downloaddir:,external-manifest:,help,image-name:,inject-mcc:,mcc-destdir:,mbl-tools-version:,outputdir:,tty,no-tty -n "$(basename "$0")" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do
   if [ -n "${opt_prev:-}" ]; then
@@ -102,6 +105,10 @@ while [ $# -gt 0 ]; do
 
   --inject-mcc)
     opt_append=inject_mcc_files
+    ;;
+
+  --mcc-destdir)
+    opt_prev=mcc_destdir
     ;;
 
   --mbl-tools-version)
@@ -166,6 +173,10 @@ if [ -n "${inject_mcc_files:-}" ]; then
     cp "$file" "$builddir/inject-mcc/$base"
     build_args="${build_args:-} --inject-mcc=$builddir/inject-mcc/$base"
   done
+fi
+
+if [ -n "${mcc_destdir:-}" ]; then
+  build_args="${build_args:-} --mcc-destdir=$mcc_destdir"
 fi
 
 # If we didn't get an mbl-tools version on the command line, try to determine

--- a/build-mbl/run-me.sh
+++ b/build-mbl/run-me.sh
@@ -42,7 +42,7 @@ OPTIONAL parameters:
                         to be injected into a build.  This is a temporary
                         mechanism to inject development keys.  Mandatory if passing
                         --mcc-destdir parameter.
-  --mcc-destdir PATH    Relative directory from bitbake ${TOPDIR} to where the file(s)
+  --mcc-destdir PATH    Relative directory from "layers" dir to where the file(s)
                         passed with --inject-mcc should be copied to.
   --mbl-tools-version STRING
                         Specify the version of mbl-tools that this script comes


### PR DESCRIPTION
The optional --mcc-destdir parameter allows the user to chose what
directory the file(s) passed with --inject-mcc should be copied to.

This directory path is relative to the "layers" path.