### PR TITLE
Increase timeout for rootfs update via Pelion

### DIFF
--- a/lava/lava-job-definitions/testplans/rootfs-update-pelion.yaml
+++ b/lava/lava-job-definitions/testplans/rootfs-update-pelion.yaml
@@ -28,7 +28,7 @@
 
 - test:
     timeout:
-      minutes: 10
+      minutes: 15
     namespace: lxc
     definitions:
     {% set rootfs_test_stage = "UPDATE" %}


### PR DESCRIPTION
Sometimes the rootfs update takes genuenly more than 10 minutes hence
increasing the timeout to 15 minutes for doing the upgrade.