### PR TITLE
Implement --local-conf-data option

### DIFF
--- a/build/mbl/build.sh
+++ b/build/mbl/build.sh
@@ -202,7 +202,7 @@ inject_custom_data()
   # configuration we inject.  We then implement a 3 stage processes:
   # 1) Remove any existing marked configuration
   # 2) Add the new required configuration, if any.
-  # 3) Atomically update the file file with the new file if
+  # 3) Atomically update the original file with the new file if
   #    anything changed.
   #
   # The atomic update ensures that if we fail, or are interrupted, we

--- a/build/mbl/build.sh
+++ b/build/mbl/build.sh
@@ -206,7 +206,7 @@ inject_custom_data()
   #    anything changed.
   #
   # The atomic update ensures that if we fail, or are interrupted, we
-  # never leave a partially updated the file  Atomic update is not
+  # never leave a partially updated original file.  Atomic update is not
   # because another process might race us!
 
   # If we previously aborted we may have left a working temporary file

--- a/build/mbl/build.sh
+++ b/build/mbl/build.sh
@@ -221,11 +221,8 @@ inject_custom_data()
     printf "# start %s\n%b\n# stop %s\n" "$name" "$custom_data" "$name" >> "$path.new"
   fi
 
-  # If anything changed then atomically update the file
-  if ! cmp -s "$path" "$path.new"; then
-    mv -f "$path.new" "$path"
-  fi
-  rm -f "$path.new"
+  # Atomically update the file
+  mv -f "$path.new" "$path"
 }
 
 setup_archiver()


### PR DESCRIPTION
This option is used to inject custom data into the local.conf.
To implement the feature the setup_archiver has been refactored in a
more generic function and then extra functions have been defined in
order to retain the old functioanlity and implement the new one.

Related ticket: IOTMBL-2325