### PR TITLE
Improve deploy mechanism for RPi3 like DUT

### DIFF
--- a/lava/lava-job-definitions/shared/templates/raspberrypi3-mbl-deploy-boot.yaml
+++ b/lava/lava-job-definitions/shared/templates/raspberrypi3-mbl-deploy-boot.yaml
@@ -19,7 +19,7 @@ actions:
     nfsrootfs:
       url: http://artifactory-proxy.mbed-linux.arm.com/artifactory/isg-mbed-linux/lava/RPI3/raspbian_rootfs.tar.xz
       compression: xz
-    os: debian
+    os: oe
     dtb:
       url: "http://artifactory-proxy.mbed-linux.arm.com/artifactory/isg-mbed-linux/lava/RPI3/mbl-os-0.5.177/{{ dtb_filename }}"
     preseed:

--- a/lava/lava-job-definitions/shared/templates/raspberrypi3-mbl-deploy-boot.yaml
+++ b/lava/lava-job-definitions/shared/templates/raspberrypi3-mbl-deploy-boot.yaml
@@ -17,9 +17,9 @@ actions:
       url: http://artifactory-proxy.mbed-linux.arm.com/artifactory/isg-mbed-linux/lava/RPI3/mbl-os-0.5.177/zImage
       type: zimage
     nfsrootfs:
-      url: http://images.validation.linaro.org/snapshots.linaro.org/openembedded/mbl/linaro-pyro-pinned/raspberrypi3/31/rpb/rpb-console-image-raspberrypi3-20171109202053-31.rootfs.tar.xz
+      url: http://artifactory-proxy.mbed-linux.arm.com/artifactory/isg-mbed-linux/lava/RPI3/raspbian_rootfs.tar.xz
       compression: xz
-    os: oe
+    os: debian
     dtb:
       url: "http://artifactory-proxy.mbed-linux.arm.com/artifactory/isg-mbed-linux/lava/RPI3/mbl-os-0.5.177/{{ dtb_filename }}"
     preseed:
@@ -34,8 +34,10 @@ actions:
     auto_login:
       login_prompt: "login:"
       username: root
+      password_prompt: 'Password:'
+      password: root
     prompts:
-    - "root@raspberrypi3:~#"
+    - "root@raspberrypi3(.*)"
     timeout:
       minutes: 5
 
@@ -64,8 +66,9 @@ actions:
           - ifconfig eth0 up
           - dir=$(cat /proc/cmdline | awk -F"lava_dir=" '{ print $2 }' | cut -d"/" -f1,2)
           - addr=http://${ip}/tftp/${dir}/preseed/mbl-image-development-raspberrypi3-mbl.wic.gz
-          - wget -O- ${addr} | gunzip -c > /dev/mmcblk0
-          - sync
+          - wget -nv -O /tmp/mbl-image-development-raspberrypi3-mbl.wic.gz ${addr}
+          # Flash the SD card
+          - bmaptool -q copy --nobmap /tmp/mbl-image-development-raspberrypi3-mbl.wic.gz ${part}
 
 # Reboot on (just flashed) SDCARD, nothing to do (minimal method)
 - boot:


### PR DESCRIPTION
Replace the old way of flashing the SD card with bmap tools.
This should improve reliability when deploying RPi3 DUT.