### PR TITLE
Increase flashing timeout for uboot-ums mechanism

### DIFF
--- a/lava/lava-job-definitions/shared/templates/uboot-ums-deploy-boot.yaml
+++ b/lava/lava-job-definitions/shared/templates/uboot-ums-deploy-boot.yaml
@@ -21,4 +21,4 @@ actions:
       - "{{ prompt }}"
 {% endfor %}
     timeout:
-      minutes: 15
+      minutes: 30


### PR DESCRIPTION
Images are getting bigger (4GB) hence we need more time to flash them
onto the DUT