### PR TITLE
Increase RPi3 flashing timeout to 15 minutes

### DIFF
--- a/lava/lava-job-definitions/shared/templates/raspberrypi3-mbl-deploy-boot.yaml
+++ b/lava/lava-job-definitions/shared/templates/raspberrypi3-mbl-deploy-boot.yaml
@@ -44,7 +44,7 @@ actions:
 - test:
     namespace: target
     timeout:
-      minutes: 10
+      minutes: 15
     definitions:
     - from: inline
       name: mmcblk0-write


### PR DESCRIPTION
This is needed because images are getting bigger hence we need more time for flashing.