### PR TITLE
license-report: Fix jinja2 template.

### DIFF
--- a/build/license-report/license_diff_report.py
+++ b/build/license-report/license_diff_report.py
@@ -329,6 +329,7 @@ def _parse_args():
         help=(
             "Images to check licenses for. For example: mbl-image-development."
         ),
+        default=["mbl-image-development"],
     )
     parser.add_argument("--apikey", help="Artifactory API key.")
     parser.add_argument(

--- a/build/license-report/template.html
+++ b/build/license-report/template.html
@@ -54,9 +54,9 @@
             {% for item in licenses %}
                 <tr>
                 {% for header in license_headers %}
-                    {% if licenses[item][header]["LICENSE STATUS"] == "NEW" %}
+                    {% if licenses[item][header] == "NEW" %}
                         <td class=new>{{licenses[item][header]}}</td>
-                    {% elif licenses[item][header]["LICENSE STATUS"] == "UPDATED" %}
+                    {% elif licenses[item][header] == "UPDATED" %}
                         <td class=update>{{licenses[item][header]}}</td>
                     {% else %}
                         <td>{{licenses[item][header]}}</td>


### PR DESCRIPTION
template.html: The jinja2 template was incorrect so the new and updated license cells 
in the HTML table didn't get the correct CSS flags applied.

license_diff_report.py: Add a default argument for '--images' as the user shouldn't have to 
pass this argument all the time in the CLI.