### PR TITLE
build.sh: Install parted in the Docker environment

### DIFF
--- a/build/common/Dockerfile
+++ b/build/common/Dockerfile
@@ -36,7 +36,8 @@ RUN apt-get update && apt-get install -y \
     unzip \
     wget \
     xterm \
-    xz-utils
+    xz-utils \
+    parted
 
 RUN apt-get update && apt-get install gosu
 RUN pip3 install dohq-artifactory && pip3 install jinja2


### PR DESCRIPTION
Without parted available in the environment the wic ls command fails.

Install parted when we build the docker image.

Fixes JIRA: IOTMBL-2371