### PR TITLE
Fix timeout of soak test RootFS update via Pelion (0.8)

### DIFF
--- a/lava/lava-job-definitions/testplans/soak-rootfs-update-pelion.yaml
+++ b/lava/lava-job-definitions/testplans/soak-rootfs-update-pelion.yaml
@@ -9,7 +9,7 @@
 {% block testplan %}
 - test:
     timeout:
-      minutes: 750 # 720 minutes is half day, we give some slack to it
+      minutes: 30
     namespace: lxc
     definitions:
 
@@ -22,6 +22,12 @@
     {{ macros.provision_mbl(venv_name) | indent }}
 
     {% for iteration in range(iterations) %}
+- test:
+    timeout:
+      minutes: 750 # 720 minutes is half day, we give some slack to it
+    namespace: lxc
+    definitions:
+
     {% if iteration is divisibleby 2 %}
         {% set rootfs = "rootfs1" %}
     {% else %}


### PR DESCRIPTION
Every update cycle needs to have its own timeout.