### PR TITLE
Increase core-components testjob timeout

### DIFF
--- a/lava/lava-job-definitions/testplans/core-components.yaml
+++ b/lava/lava-job-definitions/testplans/core-components.yaml
@@ -6,7 +6,7 @@
 {% block testplan %}
 - test:
     timeout:
-      minutes: 20
+      minutes: 30
     namespace: target
     definitions:
     {{ macros.install_test_dependencies() | indent }}


### PR DESCRIPTION
This is needed because iMX6 takes slighlty more than 20 minutes to run
the whole job due to a slower clock speed.