### PR TITLE
mbl/build: Introduce the --root-passwd-file parameter

### DIFF
--- a/build/mbl/build.sh
+++ b/build/mbl/build.sh
@@ -506,6 +506,7 @@ OPTIONAL parameters:
                         Specify the command line that was used to invoke the
                         script that invokes build.sh. This is written to
                         buildinfo.txt in the output directory.
+  --root-passwd-file    The file containing the root user password in plain text.
   --manifest-repo URL   Name the manifest URL to clone. Default ${default_manifest_repo}.
   --url           URL   Name the manifest URL to clone. Default ${default_manifest_repo}.
                         Deprecated. Use --manifest-repo instead.
@@ -538,7 +539,7 @@ flag_interactive_mode=0
 # record of how this script was invoked
 command_line="$(printf '%q ' "$0" "$@")"
 
-args=$(getopt -o+hj:o:x -l accept-eula:,archive-source,artifactory-api-key:,binary-release,branch:,builddir:,build-tag:,compress,no-compress,distro:,downloaddir:,external-manifest:,help,image:,inject-mcc:,mcc-destdir:,jobs:,licenses,licenses-buildtag:,local-conf-data:,machine:,manifest:,manifest-repo:,mbl-tools-version:,outputdir:,parent-command-line:,url: -n "$(basename "$0")" -- "$@")
+args=$(getopt -o+hj:o:x -l accept-eula:,archive-source,artifactory-api-key:,binary-release,branch:,builddir:,build-tag:,compress,no-compress,distro:,downloaddir:,external-manifest:,help,image:,inject-mcc:,mcc-destdir:,jobs:,licenses,licenses-buildtag:,local-conf-data:,machine:,manifest:,manifest-repo:,mbl-tools-version:,outputdir:,parent-command-line:,root-passwd-file:,url: -n "$(basename "$0")" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do
   if [ -n "${opt_prev:-}" ]; then
@@ -655,6 +656,10 @@ while [ $# -gt 0 ]; do
     ;;
   -o | --outputdir)
     opt_prev=outputdir
+    ;;
+
+  --root-passwd-file)
+    opt_prev=root_passwd_file
     ;;
 
   --url)
@@ -922,6 +927,12 @@ while true; do
           base="$(basename "$file")"
           cp "$file" "$builddir/machine-$machine/mbl-manifest/$mcc_final_destdir/$base"
         done
+      done
+    fi
+
+    if [ -n "${root_passwd_file:-}" ]; then
+      for machine in $machines; do
+          cp "$root_passwd_file" "$builddir/machine-$machine/mbl-manifest/build-$distro/mbl_root_passwd_file"
       done
     fi
     push_stages build

--- a/build/run-me.sh
+++ b/build/run-me.sh
@@ -86,6 +86,7 @@ OPTIONAL parameters:
   -o, --outputdir PATH  Specify a directory to store non-interactively built
                         artifacts. Note: Will not be updated by builds in
                         interactive mode.
+  --root-passwd-file    The file containing the root user password in plain text.
   --tty                 Enable tty creation (default).
   --no-tty              Disable tty creation.
   -x                    Enable shell debugging in this script.
@@ -103,7 +104,7 @@ flag_tty="-t"
 # record of how this script was invoked
 command_line="$(printf '%q ' "$0" "$@")"
 
-args=$(getopt -o+ho:x -l builddir:,project:,downloaddir:,external-manifest:,help,image-name:,inject-mcc:,mcc-destdir:,mbl-tools-version:,outputdir:,tty,no-tty -n "$(basename "$0")" -- "$@")
+args=$(getopt -o+ho:x -l builddir:,project:,downloaddir:,external-manifest:,help,image-name:,inject-mcc:,mcc-destdir:,mbl-tools-version:,outputdir:,root-passwd-file:,tty,no-tty -n "$(basename "$0")" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do
   if [ -n "${opt_prev:-}" ]; then
@@ -157,6 +158,10 @@ while [ $# -gt 0 ]; do
 
   -o | --outputdir)
     opt_prev=outputdir
+    ;;
+
+  --root-passwd-file)
+    opt_prev=root_passwd_file
     ;;
 
   --tty)
@@ -213,6 +218,12 @@ if [ -n "${inject_mcc_files:-}" ]; then
     cp "$file" "$builddir/inject-mcc/$base"
     build_args="${build_args:-} --inject-mcc=$builddir/inject-mcc/$base"
   done
+fi
+
+if [ -n "${root_passwd_file:-}" ]; then
+  base="$(basename "$root_passwd_file")"
+  cp "$root_passwd_file" "$builddir/$base"
+  build_args="${build_args:-} --root-passwd-file=$builddir/$base"
 fi
 
 build_script=$(build_script_for_project "$project")


### PR DESCRIPTION
The --root-passwd-file parameter points to the file containing the root user password in plain text.