### PR TITLE
Increase deploy timeouts

### DIFF
--- a/lava/lava-job-definitions/shared/templates/raspberrypi3-mbl-deploy-boot.yaml
+++ b/lava/lava-job-definitions/shared/templates/raspberrypi3-mbl-deploy-boot.yaml
@@ -44,7 +44,7 @@ actions:
 - test:
     namespace: target
     timeout:
-      minutes: 15
+      minutes: 30
     definitions:
     - from: inline
       name: mmcblk0-write

--- a/lava/lava-job-definitions/shared/templates/uboot-ums-deploy-boot.yaml
+++ b/lava/lava-job-definitions/shared/templates/uboot-ums-deploy-boot.yaml
@@ -21,4 +21,4 @@ actions:
       - "{{ prompt }}"
 {% endfor %}
     timeout:
-      minutes: 30
+      minutes: 60


### PR DESCRIPTION
Images are getting bigger, hence we need bigger timeouts for flashing them onto the DUT