### PR TITLE
Save local.conf as a build artifact

### DIFF
--- a/build/mbl/build.sh
+++ b/build/mbl/build.sh
@@ -983,7 +983,8 @@ while true; do
   artifact)
     if [ -n "${outputdir:-}" ]; then
       for machine in $machines; do
-        bbtmpdir="$builddir/machine-$machine/mbl-manifest/build-$distro/tmp"
+        bbbuilddir="$builddir/machine-$machine/mbl-manifest/build-$distro"
+        bbtmpdir="${bbbuilddir}/tmp"
         machinedir="$outputdir/machine/$machine"
         for image in $images; do
           imagedir="$machinedir/images/$image"
@@ -1063,6 +1064,10 @@ while true; do
           # License manifests
           artifact_image_manifests "$image" "$machine"
         done
+
+        # local.conf
+        write_info "save artifact local.conf\n"
+        cp "${bbbuilddir}/conf/local.conf" "$machinedir"
 
         # ... the license information...
         write_info "save artifact licenses\n"


### PR DESCRIPTION
Save local.conf so that the partitions test can check that partition
config added to local.conf has taken effect.

Saving local.conf is also necessary for build reproducability: if the
config has been changed by the build script then the pinned manifest no
longer fully specifies what has been built.

For IOTMBL-2282: Create build/test jobs that have non-default partition
size/offset settings

**Testing**
Tested locally by running 
```
./run-me.sh --builddir /data/work/mbed-linux/localconf-test-build --outputdir /data/work/mbed-linux/localconf-test-output -- --branch warrior-dev --machine raspberrypi3-mbl
```
then checking that local.conf made it into the output directory.