### PR TITLE
Add mechanism to inject keys into MBL build

### DIFF
--- a/build/mbl/build.sh
+++ b/build/mbl/build.sh
@@ -524,7 +524,6 @@ Useful STAGE names:
 EOF
 }
 
-set -x
 manifest_repo=""
 url=""
 mcc_final_destdir="$default_mcc_destdir"

--- a/build/mbl/build.sh
+++ b/build/mbl/build.sh
@@ -479,6 +479,8 @@ OPTIONAL parameters:
   --external-manifest PATH
                         Specify an external manifest file.
   -h, --help            Print brief usage information and exit.
+  --inject-key PATH     Add a file to the list of keys/certificates to be
+                        injected into the build.
   --image IMAGE         Select an alternative image.  Default $default_image when
                         --distro $default_distro and default $default_production_image
                         when --distro $default_production_distro.
@@ -522,6 +524,7 @@ Useful STAGE names:
 EOF
 }
 
+set -x
 manifest_repo=""
 url=""
 mcc_final_destdir="$default_mcc_destdir"
@@ -536,7 +539,7 @@ flag_interactive_mode=0
 # record of how this script was invoked
 command_line="$(printf '%q ' "$0" "$@")"
 
-args=$(getopt -o+hj:o:x -l accept-eula:,archive-source,artifactory-api-key:,binary-release,branch:,builddir:,build-tag:,compress,no-compress,distro:,downloaddir:,external-manifest:,help,image:,inject-mcc:,mcc-destdir:,jobs:,licenses,licenses-buildtag:,local-conf-data:,machine:,manifest:,manifest-repo:,mbl-tools-version:,outputdir:,parent-command-line:,root-passwd-file:,url: -n "$(basename "$0")" -- "$@")
+args=$(getopt -o+hj:o:x -l accept-eula:,archive-source,artifactory-api-key:,binary-release,branch:,builddir:,build-tag:,compress,no-compress,distro:,downloaddir:,external-manifest:,help,image:,inject-key:,inject-mcc:,mcc-destdir:,jobs:,licenses,licenses-buildtag:,local-conf-data:,machine:,manifest:,manifest-repo:,mbl-tools-version:,outputdir:,parent-command-line:,root-passwd-file:,url: -n "$(basename "$0")" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do
   if [ -n "${opt_prev:-}" ]; then
@@ -614,6 +617,10 @@ while [ $# -gt 0 ]; do
 
   --image)
     opt_prev=image
+    ;;
+
+  --inject-key)
+    opt_append=inject_key_files
     ;;
 
   --inject-mcc)
@@ -918,6 +925,15 @@ while true; do
     ;;
 
   inject)
+    if [ -n "${inject_key_files:-}" ]; then
+      for machine in $machines; do
+        for file in $inject_key_files; do
+          base="$(basename "$file")"
+          cp "$file" "$builddir/machine-$machine/mbl-manifest/build-$distro/$base"
+        done
+      done
+    fi
+
     if [ -n "${inject_mcc_files:-}" ]; then
       for machine in $machines; do
         for file in $inject_mcc_files; do

--- a/build/run-me.sh
+++ b/build/run-me.sh
@@ -72,11 +72,10 @@ MANDATORY parameters:
   --builddir PATH       Specify the root of the build tree.
 
 OPTIONAL parameters:
-  --boot-rot-key PATH   Path to the secure world root of trust private key
-                        certificate. If this option is not used, either a new
-                        certificate will be generated, or a certificate
-                        generated for a previous build in the same work area
-                        will be used.
+  --boot-rot-key PATH   Path to the secure world root of trust private key. If
+                        this option is not used, either a new key will be
+                        generated, or a key generated for a previous build in
+                        the same work area will be used.
   --downloaddir PATH    Use PATH to store Yocto downloaded sources.
   --external-manifest PATH
                         Specify an external manifest file.


### PR DESCRIPTION
For IOTMBL-2283: Implement mechanism for injecting keys/certs into
Jenkins builds for signing

**Jenkins builds**
These builds aren't using the new injection mechanism, it's just testing that I haven't broken existing functionality. I don't have a mechanism to inject keys from Jenkins yet.
* http://jenkins.mbed-linux.arm.com/view/jh/job/jh-test/152/. (Failed on imx7s-warp, seemingly due to network issue). 
* http://jenkins.mbed-linux.arm.com/view/jh/job/jh-test/153/ (Succeeded).

**Lava runs**
* http://e120856-lin/results.php?image_version=custom&image_number=153&custom_version=jh-test&lava_query=&lava_owner=&failures=false&submitter=jonhai01&sort=by_job. There was one Wi-Fi failure on imx7s-warp. Apparently we've had some issues with Wi-Fi failures over the last day or so, so I'm going to ignore this. I don't see how it could have anything to do with my changes here.

**Testing notes**
* I have done a local build for imx8mmevk using the new key injection options and verified that the keys/certs that end up in the artifact directory and the keys/certs that end up in the BitBake deploy directory match the keys/certs that were given to `run-me.sh`.
* I have tested that I can do a separate build, injecting the same keys/certs, then do successful firmware updates of BL2, BL3 and the kernel.

**Related PRs**
* https://github.com/ARMmbed/mbl-docs/pull/107 adds documentation of the new `run-me.sh` options added here.