### PR TITLE
Enable license comparison of release artifacts

### DIFF
--- a/build/mbl/build.sh
+++ b/build/mbl/build.sh
@@ -345,8 +345,6 @@ create_license_report()
   local machines=${5:?Missing machines parameter of ${FUNCNAME[0]}}
   local image=${6:?Missing images parameter of ${FUNCNAME[0]}}
 
-
-
   "./license_diff_report.py" "$build_tag" \
                              --lics-to-review "$build_lic_paths" \
                              --lics-to-compare "$prev_artifact_tag" \


### PR DESCRIPTION
Simple fix to allow builds to pass a licenses artifact path into the build.sh via:
buildExtraArgs= "--licenses-artifact-path isg-mbed-linux-release/mbed-linux/mbl-os-0.X.Y/mbl-os-0.X.Y_buildN ..."
