### PR TITLE
Allow git hosts to be added to the build environment (#319)

### DIFF
--- a/build/common/ssh-setup.sh
+++ b/build/common/ssh-setup.sh
@@ -1,22 +1,32 @@
 #!/bin/bash
 
-# Copyright (c) 2018, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2018-2019, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
 set -e
 set -u
 
-# It sets known_hosts with the right key of github.com. In this way git doesn't
-# complain about the host not being recognised when cloning repositories from
-# github via ssh
+# It sets known_hosts with the right keys for git cloud repositories.
+# In this way git doesn't complain about the host not being recognised when
+# cloning repositories via ssh.
 
-host="github.com"
+# Default cloud repos list (separated by spaces).
+# Other examples: ssh.dev.azure.com gitlab.com bitbucket.org git.code.sf.net
+# Note: We don't add these by default as it takes time to add the keys, and we
+# can't assume access.
+hosts="github.com"
+
+# List of extra hosts supplied on the command line, via the --repo-host
+# argument in build.sh
+extra_hosts="$*"
 
 mkdir -p ~/.ssh
 chmod 700 ~/.ssh
 touch ~/.ssh/known_hosts
 chmod 600 ~/.ssh/known_hosts
-if ! ssh-keygen -F "$host" > /dev/null; then
-     ssh-keyscan -H "$host" >> ~/.ssh/known_hosts
-fi
+for host in $hosts $extra_hosts; do
+    if ! ssh-keygen -F "$host" > /dev/null; then
+        ssh-keyscan -H "$host" >> ~/.ssh/known_hosts
+    fi
+done

--- a/build/mbl/build.sh
+++ b/build/mbl/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2018, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2018-2019, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
@@ -510,7 +510,10 @@ OPTIONAL parameters:
                         Specify the command line that was used to invoke the
                         script that invokes build.sh. This is written to
                         buildinfo.txt in the output directory.
-  --root-passwd-file    The file containing the root user password in plain text.
+  --repo-host NAME      Add a trusted git repository host to the build
+                        environment. Can be specified multiple times.
+  --root-passwd-file PATH
+                        The file containing the root user password in plain text.
   --manifest-repo URL   Name the manifest URL to clone. Default ${default_manifest_repo}.
   --url           URL   Name the manifest URL to clone. Default ${default_manifest_repo}.
                         Deprecated. Use --manifest-repo instead.
@@ -539,12 +542,29 @@ local_conf_data=""
 flag_licenses=0
 flag_binary_release=0
 flag_interactive_mode=0
+repo_hosts=""
 
 # Save the full command line for later - when we do a binary release we want a
 # record of how this script was invoked
 command_line="$(printf '%q ' "$0" "$@")"
 
-args=$(getopt -o+hj:o:x -l accept-eula:,archive-source,artifactory-api-key:,binary-release,branch:,builddir:,build-tag:,compress,no-compress,distro:,downloaddir:,external-manifest:,help,image:,inject-key:,inject-mcc:,mcc-destdir:,jobs:,licenses,licenses-artifact-path:,local-conf-data:,machine:,manifest:,manifest-repo:,mbl-tools-version:,outputdir:,parent-command-line:,root-passwd-file:,url: -n "$(basename "$0")" -- "$@")
+args_list="accept-eula:,archive-source,artifactory-api-key:"
+args_list="${args_list},binary-release,branch:,builddir:,build-tag:"
+args_list="${args_list},compress"
+args_list="${args_list},distro:,downloaddir:"
+args_list="${args_list},external-manifest:"
+args_list="${args_list},help"
+args_list="${args_list},image:,inject-key:,inject-mcc:"
+args_list="${args_list},jobs:"
+args_list="${args_list},licenses,licenses-artifact-path:,local-conf-data:"
+args_list="${args_list},machine:,manifest:,manifest-repo:,mbl-tools-version:"
+args_list="${args_list},mcc-destdir:"
+args_list="${args_list},no-compress"
+args_list="${args_list},outputdir:"
+args_list="${args_list},parent-command-line:"
+args_list="${args_list},repo-host:,root-passwd-file:"
+args_list="${args_list},url:"
+args=$(getopt -o+hj:o:x -l $args_list -n "$(basename "$0")" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do
   if [ -n "${opt_prev:-}" ]; then
@@ -665,6 +685,10 @@ while [ $# -gt 0 ]; do
     ;;
   -o | --outputdir)
     opt_prev=outputdir
+    ;;
+
+  --repo-host)
+    opt_append=repo_hosts
     ;;
 
   --root-passwd-file)
@@ -805,7 +829,7 @@ if empty_stages_p; then
 fi
 
 "$execdir/git-setup.sh"
-"$execdir/ssh-setup.sh"
+"$execdir/ssh-setup.sh" $repo_hosts
 
 while true; do
   if empty_stages_p; then


### PR DESCRIPTION
New build.sh options "--repo-host" that are collected and passed to ssh-setup.sh