### PR TITLE
build-update-payloads.py: deal with new payload format

### DIFF
--- a/build/mbl/build-update-payloads.py
+++ b/build/mbl/build-update-payloads.py
@@ -77,10 +77,10 @@ def main():
 
     # Create the payloads
     create_update_payload_commands = [
-        "create-update-payload -b1 -o {}/wks_bootloader1_payload.swu".format(
+        "create-update-payload -b1 -o {}/bootloader1_payload.swu".format(
             args.outputdir
         ),
-        "create-update-payload -b2 -o {}/wks_bootloader2_payload.swu".format(
+        "create-update-payload -b2 -o {}/bootloader2_payload.swu".format(
             args.outputdir
         ),
         "create-update-payload -k -o {}/kernel_payload.swu".format(

--- a/build/mbl/build-update-payloads.py
+++ b/build/mbl/build-update-payloads.py
@@ -77,14 +77,17 @@ def main():
 
     # Create the payloads
     create_update_payload_commands = [
-        "create-update-payload -b1 -o {}/wks_bootloader1_payload.tar".format(
+        "create-update-payload -b1 -o {}/wks_bootloader1_payload.swu".format(
             args.outputdir
         ),
-        "create-update-payload -b2 -o {}/wks_bootloader2_payload.tar".format(
+        "create-update-payload -b2 -o {}/wks_bootloader2_payload.swu".format(
             args.outputdir
         ),
-        "create-update-payload -k -o {}/kernel_payload.tar".format(
+        "create-update-payload -k -o {}/kernel_payload.swu".format(
             args.outputdir
+        ),
+        "create-update-payload -r {} -o {}/rootfs_payload.swu".format(
+            args.image, args.outputdir
         ),
     ]
     bitbake.run_commands(create_update_payload_commands)


### PR DESCRIPTION
We're switching to a new update payload format. Payloads will no
longer be tar files so change the filename extension for the payloads we
generate.

We have tests that generate payload files manually rather than using the
create-update-payload script in meta-mbl. Rather than updating those
tests to manually create payloads using the new format, we're going to
change them to use payloads generated by this script.

We have tests that need rootfs update payloads tests that need app
update payloads. We can generate a rootfs update payload easily enough
from this script, but we can't easily generate app update payloads from
this script yet because we haven't built the apps yet when this script
runs. Get this script to generate a rootfs payload, but leave the app
payload for later when we've moved the app build to before this script
runs.

For IOTMBL-2540: Robust update: switch to using swupdate's payload
format

**Related PRs**
* https://github.com/ARMmbed/meta-mbl/pull/730 (get create-update-payload to use new format)
* https://github.com/ARMmbed/mbl-core/pull/214 (get arm_update_activate.sh to use new format)

**Testing, Jenkins links, Lava links**
* See https://github.com/ARMmbed/meta-mbl/pull/730