### PR TITLE
Add extra error checking.

### DIFF
--- a/lava/lava-job-definitions/shared/templates/bootbomb-recovery.yaml
+++ b/lava/lava-job-definitions/shared/templates/bootbomb-recovery.yaml
@@ -44,6 +44,7 @@
            - oe
          run:
            steps:
+           - set +e
            - cd /lava-lxc
            - dpkg -i imx-usb-loader_0-git20181105.4aa98090-1_amd64.deb
            - lsusb
@@ -51,11 +52,13 @@
            - DEVICE_PATH=$(grep 15a2 /sys/bus/usb/devices/*/idVendor |grep "$LAVA_STORAGE_INFO_0_SATA" |awk '{split($0,a,"/idVendor"); print a[1]}')
            - BUSNUM=$(cat $DEVICE_PATH/busnum)
            - DEVICENUM=$(cat $DEVICE_PATH/devnum)
-           - imx_usb --bus=$BUSNUM --device=$DEVICENUM {{ bootbomb_filename }}
+           - imx_usb --bus=$BUSNUM --device=$DEVICENUM {{ bootbomb_filename }} || lava-test-raise "imx_usb failed"
              # Sleep to allow the bootbomb to start up.
            - sleep 30
            - ls -al $LAVA_STORAGE_INFO_0_BLOCK || lava-test-raise "block device not found"
+           - dmesg -T 
            - bmaptool --quiet copy --bmap /lava-lxc/*.wic.bmap /lava-lxc/*.wic.gz $LAVA_STORAGE_INFO_0_BLOCK || lava-test-raise "recovery flash operation failed"
+           - set -e
 
 - boot:
     namespace: recovery


### PR DESCRIPTION
If the imx_usb command fails the job will now fail instead of carrying on with the wrong image.