### PR TITLE
Add script to run Bash commands in the build environment

### DIFF
--- a/build/common/Dockerfile
+++ b/build/common/Dockerfile
@@ -77,4 +77,8 @@ COPY poky-test/build-poky.py \
      poky-test/poky-bitbake-wrapper.sh ./
 
 # Scripts used to build BL2/BL3/fitImage components
-COPY mbl/build-update-payloads.py ./
+COPY common/bitbake_util.py \
+     mbl/build-update-payloads.py ./
+
+# Scripts used to run commands in build environment
+COPY mbl/run-command.py ./

--- a/build/common/bitbake_util.py
+++ b/build/common/bitbake_util.py
@@ -115,9 +115,7 @@ class Bitbake(object):
             cd_command = "cd {} &&".format(quote(str(kwargs["cwd"])))
 
         full_command = "{} && {} {}".format(
-            self._generate_setup_env_command(),
-            cd_command,
-            command,
+            self._generate_setup_env_command(), cd_command, command
         )
 
         if verbose:

--- a/build/common/bitbake_util.py
+++ b/build/common/bitbake_util.py
@@ -71,13 +71,10 @@ class Bitbake(object):
         self._validate_parameters()
         self._check_environment()
 
-    def _generate_setup_env_command(self, verbose=False):
+    def _generate_setup_env_command(self):
         """Generate a Bash command to set up the BitBake environment."""
-        redirect_str = ""
-        if not verbose:
-            redirect_str = ">/dev/null"
-        return ". {} build-{} {}".format(
-            quote(self.init_env_file), quote(self.distro), redirect_str
+        return ". {} build-{}".format(
+            quote(self.init_env_file), quote(self.distro)
         )
 
     def run_command(self, command, verbose=False, **kwargs):
@@ -118,7 +115,7 @@ class Bitbake(object):
             cd_command = "cd {} &&".format(quote(str(kwargs["cwd"])))
 
         full_command = "{} && {} {}".format(
-            self._generate_setup_env_command(verbose=verbose),
+            self._generate_setup_env_command(),
             cd_command,
             command,
         )

--- a/build/mbl/build-update-payloads.py
+++ b/build/mbl/build-update-payloads.py
@@ -87,7 +87,7 @@ def main():
         "bitbake {}".format(args.image),
     ]
     for command in bitbake_build_commands:
-        bitbake.run_command(command, check=True)
+        bitbake.run_command(command, check=True, verbose=True)
 
     # Create the payloads
     bootloader1_base_path = args.outputdir / "bootloader1_payload"
@@ -110,7 +110,7 @@ def main():
         ),
     ]
     for command in create_update_payload_commands:
-        bitbake.run_command(command, check=True)
+        bitbake.run_command(command, check=True, verbose=True)
 
 
 if __name__ == "__main__":

--- a/build/mbl/run-command.py
+++ b/build/mbl/run-command.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Script to run a Bash command inside the MBL build environment."""
+
+import argparse
+import sys
+
+import bitbake_util
+import file_util
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--builddir",
+        metavar="DIR",
+        type=file_util.str_to_resolved_path,
+        help="directory in which to build",
+        required=True,
+    )
+    parser.add_argument(
+        "--machine", metavar="STRING", help="Machine to build.", required=True
+    )
+    parser.add_argument(
+        "--distro",
+        metavar="STRING",
+        help="Name of the distro to build.",
+        default="mbl-development",
+        required=False,
+    )
+    parser.add_argument(
+        "--command",
+        metavar="STRING",
+        help="Bash command to run in build environment.",
+        required=True,
+    )
+
+    args, _ = parser.parse_known_args()
+    file_util.ensure_is_directory(args.builddir)
+    return args
+
+
+def main():
+    """Script entry point."""
+    args = _parse_args()
+
+    bitbake = bitbake_util.Bitbake(
+        builddir=args.builddir, machine=args.machine, distro=args.distro
+    )
+    return bitbake.run_command(args.command).returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/run-me.sh
+++ b/build/run-me.sh
@@ -29,6 +29,25 @@ cleanup() {
     fi
 }
 
+quiet_printf() {
+    if [ "$quiet" -ne 1 ]; then
+        # Shellcheck warns about printf's format string being variable, but
+        # quiet_printf is just forwarding args to printf, so it's
+        # quiet_printf's caller's responsibility to ensure that quiet_printf's
+        # format string isn't variable.
+        # shellcheck disable=SC2059
+        printf "$@"
+    fi
+}
+
+run_quietly() {
+    if [ "$quiet" -ne 1 ]; then
+        "$@"
+    else
+        "$@" > /dev/null
+    fi
+}
+
 build_script_for_project() {
     project=${1:?}
     case "$1" in
@@ -43,6 +62,9 @@ build_script_for_project() {
             ;;
         pelion-edge)
             printf "%s\n" "build.py"
+            ;;
+        run-command)
+            printf "%s\n" "run-command.py"
             ;;
         *)
             printf "Unrecognized project (build_script) \"%s\"" "$project" >&2
@@ -65,6 +87,9 @@ dockerfile_for_project() {
             ;;
         pelion-edge)
             printf "%s\n" "pelion-edge/Dockerfile"
+            ;;
+        run-command)
+            printf "%s\n" "common/Dockerfile"
             ;;
         *)
             printf "Unrecognized project (dockerfile) \"%s\"" "$project" >&2
@@ -134,6 +159,7 @@ OPTIONAL parameters:
   -o, --outputdir PATH  Specify a directory to store non-interactively built
                         artifacts. Note: Will not be updated by builds in
                         interactive mode.
+  --quiet               Reduce amount of output.
   --root-passwd-file PATH
                         The file containing the root user password in plain text.
   --save-config PATH    Path to the file to record the currently specified command
@@ -155,12 +181,19 @@ EOF
 imagename="$default_imagename"
 project="$default_project"
 flag_tty="-t"
+quiet=0
 
 # Read or write configuration files and return combined args array
 config=()
 config_setup config "$@"
+
 # Set up args including values from config
-eval set -- "${config[@]}"
+# Shell check wants us to quote the printf substitution to prevent word
+# splitting here, but we *want* word splitting of printf's output. The "%q" in
+# printf's format string means that the word splitting will happen in the right
+# places.
+# shellcheck disable=SC2046
+eval set -- $(printf '%q ' "${config[@]}")
 
 # Save the full command line for later - when we do a binary release we want a
 # record of how this script was invoked
@@ -176,6 +209,7 @@ args_list="${args_list},mcc-destdir:,mbl-tools-version:"
 args_list="${args_list},no-tty"
 args_list="${args_list},outputdir:"
 args_list="${args_list},project:"
+args_list="${args_list},quiet"
 args_list="${args_list},root-passwd-file:"
 args_list="${args_list},ssh-auth-keys:"
 args_list="${args_list},tty"
@@ -249,6 +283,10 @@ while [ $# -gt 0 ]; do
     opt_prev=outputdir
     ;;
 
+  --quiet)
+    quiet=1
+    ;;
+
   --root-passwd-file)
     opt_prev=root_passwd_file
     ;;
@@ -280,7 +318,7 @@ done
 if [ -n "${builddir:-}" ]; then
   builddir=$(readlink -f "$builddir")
   if [ ! -d "$builddir" ]; then
-    printf "missing builddir %s. Creating it.\n" "$builddir"
+    quiet_printf "missing builddir %s. Creating it.\n" "$builddir"
     mkdir -p "$builddir"
   fi
 else
@@ -291,7 +329,7 @@ fi
 if [ -n "${outputdir:-}" ]; then
   outputdir=$(readlink -f "$outputdir")
   if [ ! -d "$outputdir" ]; then
-    printf "missing outputdir %s. Creating it.\n" "$outputdir"
+    quiet_printf "missing outputdir %s. Creating it.\n" "$outputdir"
     mkdir -p "$outputdir"
   fi
 fi
@@ -299,7 +337,7 @@ fi
 if [ -n "${downloaddir:-}" ]; then
   downloaddir=$(readlink -f "$downloaddir")
   if [ ! -d "$downloaddir" ]; then
-    printf "missing downloaddir %s. Creating it.\n" "$downloaddir"
+    quiet_printf "missing downloaddir %s. Creating it.\n" "$downloaddir"
     mkdir -p "$downloaddir"
   fi
 fi
@@ -359,11 +397,11 @@ fi
 # environments so don't fail the build if it doesn't work.
 if [ -z "${mbl_tools_version:-}" ]; then
   if which git &> /dev/null; then
-    printf "Found git in path; attempting to determine mbl-tools version\n"
+    quiet_printf "Found git in path; attempting to determine mbl-tools version\n"
     if mbl_tools_version=$(git -C "$(dirname "$0")" rev-parse HEAD); then
-      printf "Determined mbl-tools version to be %s\n" "$mbl_tools_version";
+      quiet_printf "Determined mbl-tools version to be %s\n" "$mbl_tools_version";
     else
-      printf "Failed to determine mbl-tools version automatically; continuing anyway\n" >&2
+      quiet_printf "Failed to determine mbl-tools version automatically; continuing anyway\n" >&2
       mbl_tools_version=""
     fi
   fi
@@ -377,7 +415,7 @@ if [ -z "${SSH_AUTH_SOCK+false}" ]; then
 fi
 
 # Build the docker build environment
-docker build -f "$execdir/$dockerfile" -t "$imagename" "$execdir"
+run_quietly docker build -f "$execdir/$dockerfile" -t "$imagename" "$execdir"
 
 if [ -n "${external_manifest:-}" ]; then
   name="$(basename "$external_manifest")"

--- a/build/run-me.sh
+++ b/build/run-me.sh
@@ -198,7 +198,7 @@ config_setup config "$@"
 # printf's format string means that the word splitting will happen in the right
 # places.
 # shellcheck disable=SC2046
-eval set -- $(printf '%q ' "${config[@]}")
+eval set -- "${config[@]}"
 
 # Save the full command line for later - when we do a binary release we want a
 # record of how this script was invoked


### PR DESCRIPTION
build/mbl/run-command.py:
* Add script to run arbitrary Bash commands in the MBL build
  environment.

build/common/Dockerfile:
* Add the script to our docker container.

build/common/bitbake_util.py:
* Add "verbose" options to functions so that I don't always have to see
  verbose output.

build/mbl/build-update-payloads.py:
* Update to use the new "verbose" options in bitbake_util.py.

build/run-me.sh:
* Add a "project" for running commands in the build container via
  run-command.py.
* Add a "--quiet" option so that command output doesn't get drowned in
  noise from e.g. "docker build".
* Escape some values used in an "eval" so that it doesn't try to
  interpret special characters in command line arguments, which may be
  more common now that one of the command line arguments can be a Bash
  command.

**Jenkins links**
* http://jenkins.mbed-linux.arm.com/blue/organizations/jenkins/jh-test/detail/jh-test/171/pipeline (before switch to `subprocess.run()`).
* http://jenkins.mbed-linux.arm.com/view/jh/job/jh-test/174/ (failed, shows output buffering issue).
* http://jenkins.mbed-linux.arm.com/view/jh/job/jh-test/193/ (failed with `error: missing parameter --builddir PATH`; after rebase/force-push and confict resolution).
* http://jenkins.mbed-linux.arm.com/view/jh/job/jh-test/194/ (succeeded; after fix for `error: missing parameter --builddir PATH`)