### PR TITLE
Fix LAVA pipeline for production images

### DIFF
--- a/lava/lava-job-definitions/shared/templates/base.yaml
+++ b/lava/lava-job-definitions/shared/templates/base.yaml
@@ -32,6 +32,9 @@ metadata:
     td-database: "{{ treasure_database }}"
 {% endif %}
 
+context:
+  kernel_start_message: ""
+
 priority: medium
 visibility: public
 


### PR DESCRIPTION
After LAVA flashes the board, it understand the board has booted depending on some strings in the serial console. Production image doesn't show any message while booting, so LAVA waits forever and the job times out.
We can set the kernel_start_message to an empty string so we can tell LAVA to start waiting for the prompt straight away after the power up.