### PR TITLE
maintenance/release.xml: Set the default revision to master

### DIFF
--- a/maintenance/release.xml
+++ b/maintenance/release.xml
@@ -5,7 +5,7 @@
 
   <remote fetch="ssh://git@github.com" name="origin"/>
 
-  <default revision="warrior-dev" sync-j="4"/>
+  <default revision="master" sync-j="4"/>
 
   <project name="armmbed/mbl-manifest" remote="origin"/>
   <project name="armmbed/meta-mbl" remote="origin"/>


### PR DESCRIPTION
To be able to create development and release branches from master
the default revision for the maintenance/release.xml manifest needs
to point to master.