### PR TITLE
build-update-payloads.py: add new deps and create testinfo files

### DIFF
--- a/build/common/Dockerfile
+++ b/build/common/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN apt-get update && apt-get install gosu
 RUN pip3 install -U pip
-RUN pip3 install dohq-artifactory jinja2 pexpect
+RUN pip3 install arpy dohq-artifactory jinja2 libconf pexpect
 COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Use the 'exec' form of ENTRYPOINT to ensure that docker run

--- a/build/mbl/build-update-payloads.py
+++ b/build/mbl/build-update-payloads.py
@@ -76,18 +76,23 @@ def main():
     bitbake.run_commands(bitbake_build_commands)
 
     # Create the payloads
+    bootloader1_base_path = args.outputdir / "bootloader1_payload"
+    bootloader2_base_path = args.outputdir / "bootloader2_payload"
+    kernel_base_path = args.outputdir / "kernel_payload"
+    rootfs_base_path = args.outputdir / "rootfs_payload"
+
     create_update_payload_commands = [
-        "create-update-payload -b1 -o {}/bootloader1_payload.swu".format(
-            args.outputdir
+        "create-update-payload -b1 -o {0}.swu -t {0}.testinfo".format(
+            bootloader1_base_path
         ),
-        "create-update-payload -b2 -o {}/bootloader2_payload.swu".format(
-            args.outputdir
+        "create-update-payload -b2 -o {0}.swu -t {0}.testinfo".format(
+            bootloader2_base_path
         ),
-        "create-update-payload -k -o {}/kernel_payload.swu".format(
-            args.outputdir
+        "create-update-payload -k -o {0}.swu -t {0}.testinfo".format(
+            kernel_base_path
         ),
-        "create-update-payload -r {} -o {}/rootfs_payload.swu".format(
-            args.image, args.outputdir
+        "create-update-payload -r {0} -o {1}.swu -t {1}.testinfo".format(
+            args.image, rootfs_base_path
         ),
     ]
     bitbake.run_commands(create_update_payload_commands)


### PR DESCRIPTION
* The create-update-payload script that build-update-payloads.py uses
  now has dependencies on the Python arpy and libconf modules so add
  them to the build container.

* get create-update-payload to generate "testinfo" files containing
  information about how to test the payloads.

**Related PRs (synchronize merges)**
* https://github.com/ARMmbed/meta-mbl/pull/763 (Update create-update-payload for new payload format)
* https://github.com/ARMmbed/mbl-core/pull/233 (Integrate swupdate into update flow and use new payload format).

**Jenkins links**
* http://jenkins.mbed-linux.arm.com/view/jh/job/jh-test/172/ (in progress)