### PR TITLE
master: sync up with warrior-dev

### DIFF
--- a/build/common/Dockerfile
+++ b/build/common/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN apt-get update && apt-get install gosu
 RUN pip3 install -U pip
-RUN pip3 install dohq-artifactory jinja2 pexpect
+RUN pip3 install arpy dohq-artifactory jinja2 libconf pexpect
 COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Use the 'exec' form of ENTRYPOINT to ensure that docker run

--- a/build/common/config-funcs.sh
+++ b/build/common/config-funcs.sh
@@ -1,0 +1,328 @@
+#!/bin/bash
+
+# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# BASH functions that can be "source"d into a script to provide simple
+# config functionality that supports command line options:
+#   --save-config FILE      - save all the arguments into FILE and exit
+#   --load-config FILE      - load arguments from FILE and combine them
+#                             with the command line arguments
+#
+# Example usage to replace command line args ($@) with extra args from config:
+#   source config-funcs.sh
+#   config=()
+#   config_setup config "$@"
+#   eval set -- "${config[@]}"
+#
+# Notes:
+# * only supports options without values or options with a single value
+# * supports "--" option that splits primary and secondary arguments
+# * SC2178: Arrays passed around by reference confuses shellcheck
+#           https://github.com/koalaman/shellcheck/issues/1225
+# * SC2034: Arrays passed around by reference confuses shellcheck
+#           https://github.com/koalaman/shellcheck/issues/1543
+
+
+# Read arguments and values from a file
+# Split them into primary and secondary based on "--" in the file
+# Return bash arrays for the arguments and values to preserve spaces in values
+# Params: NAME ARRAY_REF ARRAY_REF
+_config_read_args()
+{
+  # Config filename and path
+  local config="$1"
+  # Array variable reference to put the arguments into
+  local -n config_primary=$2
+  local -n config_secondary=$3
+  local stage=1
+  if [ -r "$config" ]; then
+    while read -r line; do
+      if [[ "$line" =~ ^--\ *$ ]]; then
+        # Switch to secondary stage on "--"
+        stage=2
+        continue  # Skip the "--"
+      fi
+      local val
+      pat="^-[-a-z]+="
+      if [[ "$line" =~ $pat ]]; then
+        # Catch --option=value and don't split it
+        val="$line"
+      else
+        # Split the arguments and values for the array
+        val=${line#-* } # Remove the argument part
+      fi
+      if [ "$val" == "$line" ]; then
+        # No value, only an option (or option=value)
+        if [ $stage -eq 1 ]; then
+          config_primary+=("$line")
+        else
+          config_secondary+=("$line")
+        fi
+      else
+        local opt=${line% $val}
+        if [ $stage -eq 1 ]; then
+          config_primary+=("$opt" "$val")
+        else
+          config_secondary+=("$opt" "$val")
+        fi
+      fi
+    done < "$config"
+  fi
+}
+
+# Write arguments and values to a config file
+# Outputs the arguments as argument and value on the same line
+# NOTE: "--END--" must be last entry in list to end processing/output of the list
+# Params: NAME ARGS_LIST... --END--
+_config_write_args()
+{
+  # Config filename and path
+  local config="$1"
+  shift
+  if [ ! -e "$config" ] || [[ -w "$config" && -f "$config" ]]; then
+    # Create empty file
+    rm -f "$config"
+    touch "$config"
+    local lastarg=""
+    # Go through the other arguments (and values) saving them to a file
+    # "--END--" is assumed to be the last arg in the list (which is not output)
+    #  this forces the loop to output the "lastarg" before exiting
+    while [ $# -gt 0 ]; do
+      local arg="$1"
+      shift
+      if [ -z "$arg" ]; then
+        # Ignore empty arguments
+        continue
+      fi
+      if [[ "$arg" =~ ^- ]]; then
+        # An argument, output any previous argument on its own
+        if [ -n "$lastarg" ]; then
+          echo "$lastarg" >> "$config"
+        fi
+        lastarg=$arg
+      else
+        # A value - group arguments and values together
+        if [ -n "$lastarg" ]; then
+          echo "$lastarg $arg" >> "$config"
+        else
+          echo "$arg" >> "$config"
+        fi
+        lastarg=""
+      fi
+      if [ "$arg" == "--END--" ]; then
+        break
+      fi
+    done
+  fi
+}
+
+# Given a config, this will try and read args from that file
+# The arguments are split by "--" returned in bash arrays in the given refs
+# Params: NAME ARRAY_REF ARRAY_REF
+_config_read()
+{
+  local config="$1"
+  # shellcheck disable=SC2178
+  local -n config_primary=$2
+  # shellcheck disable=SC2178
+  local -n config_secondary=$3
+
+  if [ -r "${config}" ]; then
+    _config_read_args "${config}" "${!config_primary}" "${!config_secondary}"
+    if [ ${#config_primary[@]} -gt 0 ] || [ ${#config_secondary[@]} -gt 0 ]; then
+      echo "Read configuration from ${config}"
+    fi
+  else
+    echo "ERROR: Unreadable configuration file ${config}"
+    return 1
+  fi
+}
+
+# Write out the arguments to the given file
+# Params: NAME ARGS_LIST...
+_config_write()
+{
+  local config_file="$1"
+  shift
+  if [ -d "$(dirname "$config_file")" ]; then
+    if [ ! -e "$config_file" ] || [[ -w "$config_file" && -f "$config_file" ]]; then
+      echo "Saving configuration to $config_file"
+      _config_write_args "$config_file" "$@" "--END--"
+    else
+      echo "ERROR: Cannot write $config_file as invalid file"
+    fi
+  else
+    echo "ERROR: Cannot write $config_file as directory is invalid"
+    return 1
+  fi
+}
+
+# Read through the arguments for the given config option (without --) so we can
+# remove the option and return the option value - filename
+# Needs a reference to store the filename and the updated args list, and then
+# the full list of args to parse
+# option
+# NOTE: "--END--" must be last entry in list to end processing/output of the list
+# Params: NAME NAME_REF ARRAY_REF ARGS_LIST... --END--
+_config_get_filename()
+{
+  # We need to read the option to get the filename
+  local optname=$1
+  local -n ret_filename=$2
+  local -n ret_args=$3
+  shift 3
+  ret_args=()
+
+  # Go through each option/value looking for the option we want, and remove it
+  local lastarg=""
+  local optreturn=""
+  while [ $# -gt 0 ]; do
+    local arg="$1"
+    shift
+    if [ -z "$arg" ]; then
+      # Ignore empty arguments
+      continue
+    fi
+    local optcheck
+    if [[ "$arg" =~ ^- ]]; then
+      # An argument, check if the lastarg is the option we want
+      # (it will be in the form --option=value)
+      if [ -n "$lastarg" ]; then
+        set +e
+        optcheck=$(getopt -q -o+ -l "$optname:" -- "$lastarg")
+        set -e
+        # getopt returns " --" if its not the option we want
+        if [ "$optcheck" == " --" ]; then
+          ret_args+=("$lastarg")
+        else
+          # Save the output from getopt for later
+          optreturn="$optcheck"
+        fi
+      fi
+      # Save the argument to look at later with a possibly value
+      lastarg=$arg
+    else
+      # A value - check using the last argument and this value for the option
+      # (form of --option value)
+      set +e
+      optcheck=$(getopt -q -o+ -l "$optname:" -- "$lastarg" "$arg")
+      set -e
+      # getopt returns " -- '$arg'" if its not found as it removes unknown opts
+      if [[ "$optcheck" =~ ^\ --\  ]]; then
+          if [ -n "$lastarg" ]; then
+            ret_args+=("$lastarg")
+          fi
+          ret_args+=("$arg")
+      else
+        # Save the output from getopt for later
+        optreturn="$optcheck"
+      fi
+      lastarg=""
+    fi
+    if [ "$arg" == "--END--" ]; then
+      break
+    fi
+  done
+  ret_filename=""
+  if [ -n "$optreturn" ]; then
+    # Extract the file from the last found "--option 'FILE' --"
+    ret_filename=${optreturn##*$optname \'}
+    ret_filename=${ret_filename%%\' --*}
+  fi
+}
+
+# Combine the command line (cl) arguments with the config arguments, such that:
+# [primary config] [cl args (before --)] -- [secondary args] [cl args (after --)]
+# Params: ARRAY_REF ARRAY_REF ARRAY_REF ARGS_LIST...
+_config_combine_args()
+{
+  # shellcheck disable=SC2178
+  local -n ret_args=$1
+  # shellcheck disable=SC2178
+  local -n config_primary=$2
+  # shellcheck disable=SC2178
+  local -n config_secondary=$3
+  shift 3
+  ret_args=()
+
+  # Put the primary config args first
+  local arg
+  set +u # Ignore if the config_primary array is empty
+  for arg in "${config_primary[@]}"; do
+    ret_args+=("$arg")
+  done
+  set -u
+  # Next add all the command line arguments upto "--"
+  while [ $# -gt 0 ]; do
+    arg="$1"
+    shift
+    if [[ "$arg" =~ ^--\ *$ ]]; then
+      # Found "--" exit the loop without recording it as we may get arguments
+      # that don't contain "--"
+      break
+    fi
+    ret_args+=("$arg")
+  done
+  # Add the delimiter between args (in case it wasn't in the command line)
+  ret_args+=("--")
+  # Now add the secondary config args
+  set +u # Ignore if the config_secondary array is empty
+  for arg in "${config_secondary[@]}"; do
+    ret_args+=("$arg")
+  done
+  set -u
+  # Lastly add any remaining args
+  while [ $# -gt 0 ]; do
+    ret_args+=("$1")
+    shift
+  done
+}
+
+# Single config read/write function
+# First parameter is used on read and is an array populated with the combined
+# command line and config arguments
+# Rest of parameters are the command line args passed via "$@"
+# On write, command line args are written to file and then exit
+# Params: ARRAY_REF ARGS_LIST...
+config_setup()
+{
+  local -n config_args=$1
+  shift
+
+  # Avoid circular references by unique naming of arrays
+  local __args=()
+  # shellcheck disable=SC2034
+  local __config_primary=()
+  # shellcheck disable=SC2034
+  local __config_secondary=()
+
+  local config_load=""
+  _config_get_filename "load-config" config_load __args "$@" "--END--"
+  local config_save=""
+  set +u  # __args could be empty, so allow unbound vars
+  _config_get_filename "save-config" config_save __args "${__args[@]}" "--END--"
+  set -u
+
+  if [ -n "$config_load" ] || [ -n "$config_save" ]; then
+    if [ "$config_save" == "$config_load" ]; then
+      echo "ERROR: Unsupported loading and saving to same config file - $config_save"
+      exit 2
+    fi
+  fi
+
+  # Support loading from one config and saving to another
+  if [ -n "$config_load" ]; then
+    _config_read "$config_load" __config_primary __config_secondary
+  fi
+  set +u  # __args could be empty, so allow unbound vars
+  _config_combine_args "${!config_args}" __config_primary __config_secondary "${__args[@]}"
+  set -u
+  if [ -n "$config_save" ]; then
+    set +u  # __args could be empty, so allow unbound vars
+    _config_write "$config_save" "${config_args[@]}"
+    set -u
+    exit 0
+  fi
+}

--- a/build/mbl/build-update-payloads.py
+++ b/build/mbl/build-update-payloads.py
@@ -77,14 +77,17 @@ def main():
 
     # Create the payloads
     create_update_payload_commands = [
-        "create-update-payload -b1 -o {}/wks_bootloader1_payload.tar".format(
+        "create-update-payload -b1 -o {}/bootloader1_payload.swu".format(
             args.outputdir
         ),
-        "create-update-payload -b2 -o {}/wks_bootloader2_payload.tar".format(
+        "create-update-payload -b2 -o {}/bootloader2_payload.swu".format(
             args.outputdir
         ),
-        "create-update-payload -k -o {}/kernel_payload.tar".format(
+        "create-update-payload -k -o {}/kernel_payload.swu".format(
             args.outputdir
+        ),
+        "create-update-payload -r {} -o {}/rootfs_payload.swu".format(
+            args.image, args.outputdir
         ),
     ]
     bitbake.run_commands(create_update_payload_commands)

--- a/build/mbl/build-update-payloads.py
+++ b/build/mbl/build-update-payloads.py
@@ -76,18 +76,23 @@ def main():
     bitbake.run_commands(bitbake_build_commands)
 
     # Create the payloads
+    bootloader1_base_path = args.outputdir / "bootloader1_payload"
+    bootloader2_base_path = args.outputdir / "bootloader2_payload"
+    kernel_base_path = args.outputdir / "kernel_payload"
+    rootfs_base_path = args.outputdir / "rootfs_payload"
+
     create_update_payload_commands = [
-        "create-update-payload -b1 -o {}/bootloader1_payload.swu".format(
-            args.outputdir
+        "create-update-payload -b1 -o {0}.swu -t {0}.testinfo".format(
+            bootloader1_base_path
         ),
-        "create-update-payload -b2 -o {}/bootloader2_payload.swu".format(
-            args.outputdir
+        "create-update-payload -b2 -o {0}.swu -t {0}.testinfo".format(
+            bootloader2_base_path
         ),
-        "create-update-payload -k -o {}/kernel_payload.swu".format(
-            args.outputdir
+        "create-update-payload -k -o {0}.swu -t {0}.testinfo".format(
+            kernel_base_path
         ),
-        "create-update-payload -r {} -o {}/rootfs_payload.swu".format(
-            args.image, args.outputdir
+        "create-update-payload -r {0} -o {1}.swu -t {1}.testinfo".format(
+            args.image, rootfs_base_path
         ),
     ]
     bitbake.run_commands(create_update_payload_commands)

--- a/build/mbl/build.sh
+++ b/build/mbl/build.sh
@@ -92,7 +92,7 @@ repo_init_atomic ()
 all_machines="imx7s-warp-mbl raspberrypi3-mbl imx7d-pico-mbl imx8mmevk-mbl imx6ul-pico-mbl imx6ul-des0258-mbl"
 
 default_manifest="default.xml"
-default_manifest_repo="git@github.com:ARMmbed/mbl-manifest.git"
+default_manifest_repo="https://github.com/ARMmbed/mbl-manifest.git"
 default_distro="mbl-development"
 default_image="mbl-image-development"
 default_production_distro="mbl-production"

--- a/build/tests/tcf_load2.cfg
+++ b/build/tests/tcf_load2.cfg
@@ -1,0 +1,6 @@
+--some option
+--equals=with spaces
+--another
+--
+--extra args with spaces
+--yes

--- a/build/tests/tcf_ls_load1.cfg
+++ b/build/tests/tcf_ls_load1.cfg
@@ -1,0 +1,9 @@
+--some option
+--equals=with spaces
+--another
+--new test opt
+--maybe
+--
+--extra args with spaces
+--yes
+--wildcard ****

--- a/build/tests/test_config-funcs.sh
+++ b/build/tests/test_config-funcs.sh
@@ -1,0 +1,241 @@
+#!/bin/bash +e
+
+# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Testing of the config functionality
+
+# Notes:
+# * SC2178: Arrays passed around by reference confuses shellcheck
+# * SC2034: Arrays passed around by reference confuses shellcheck
+
+
+execdir="$(readlink -e "$(dirname "$0")")"
+srcdir="$execdir/../common"
+
+# shellcheck disable=SC1090
+source "$srcdir/config-funcs.sh"
+
+validate_args()
+{
+  local -n list1=$1
+  local -n list2=$2
+  local invalid=0
+
+  if [ ${#list1[@]} -ne ${#list2[@]} ]; then
+    # Different lengths
+    invalid=1
+    echo "ERR: found different lengths of args"
+  fi
+  for i in "${!list1[@]}"; do
+      if [ "${list1[$i]}" != "${list2[$i]}" ]; then
+        echo "ERR: non-matching arg [${list1[$i]}] != [${list2[$i]}]"
+        invalid=1
+        break
+      fi
+  done
+  set +e
+  if [ $invalid -eq 1 ]; then
+    echo "FAIL: [${list1[*]}] != [${list2[*]}]"
+    return 1
+  else
+    echo "PASS"
+    return 0
+  fi
+}
+
+validate_output()
+{
+  local out=$1
+  local exp=$2
+
+  set +e
+  if [ "$out" == "$exp" ]; then
+    echo "PASS"
+    return 0
+  else
+    echo "FAIL: Incorrect output [$out]"
+    return 1
+  fi
+}
+
+validate_files()
+{
+  local out=$1
+  local exp=$2
+
+  set +e
+  diff "$out" "$exp"
+  ret=$?
+  if [ $ret -ne 0 ]; then
+    echo "FAIL: Differences found between $out and $exp"
+    return 1
+  fi
+  return 0
+}
+
+validate_output_and_files()
+{
+  local out=$1
+  local exp=$2
+  local fout=$3
+  local fexp=$4
+
+  local ret
+  ret=$(validate_output "$out" "$exp")
+  if [ "$ret" == "PASS"  ]; then
+    validate_files "$fout" "$fexp"
+    return $?
+  else
+    echo "$ret"
+    return 1
+  fi
+}
+
+remove_save_file()
+{
+  local file=$1
+  if [ -e "$file" ]; then
+    set -e
+    rm "$file"
+    set +e
+  fi
+}
+
+# Tests
+
+test_opts1()
+{
+  echo "Test: No config options"
+  local ainput=("--no" "matching" "--config" "options")
+  local aoutput=()
+  local aexpected=("--no" "matching" "--config" "options" "--")
+  config_setup aoutput "${ainput[@]}"
+  validate_args aoutput aexpected
+  return $?
+}
+
+test_opts2()
+{
+  echo "Test: load-config and save-config with same file"
+  local ainput=("--load-config" "same.cfg" "--save-config" "same.cfg")
+  local output
+  output=$(config_setup output "${ainput[@]}")
+  local expected="ERROR: Unsupported loading and saving to same config file - same.cfg"
+  validate_output "$output" "$expected"
+}
+
+test_opts3()
+{
+  echo "Test: load and save (shortened) with same file "
+  local ainput=("--load" "same.cfg" "--save" "same.cfg")
+  local output
+  output=$(config_setup output "${ainput[@]}")
+  local expected="ERROR: Unsupported loading and saving to same config file - same.cfg"
+  validate_output "$output" "$expected"
+}
+
+test_opts4()
+{
+  echo "Test: load-config= and save= (equals style) with same file "
+  local ainput=("--load-config=same.cfg" "--save=same.cfg")
+  local output
+  output=$(config_setup output "${ainput[@]}")
+  local expected="ERROR: Unsupported loading and saving to same config file - same.cfg"
+  validate_output "$output" "$expected"
+}
+
+test_load1()
+{
+  echo "Test: load-config with invalid file"
+  local ainput=("--load-config" "invalid.cfg")
+  local output
+  output=$(config_setup output "${ainput[@]}")
+  local expected="ERROR: Unreadable configuration file invalid.cfg"
+  validate_output "$output" "$expected"
+  return $?
+}
+
+# shellcheck disable=SC2034
+TEST2=("--some" "option" "--equals=with spaces" "--another" "--" "--extra" "args with spaces" "--yes")
+
+test_load2()
+{
+  echo "Test: load-config with valid file"
+  local ainput=("--load-config" "tcf_load2.cfg")
+  # shellcheck disable=SC2034
+  local aoutput=()
+  # shellcheck disable=SC2034 disable=SC2178
+  local -n aexpected=TEST2
+  config_setup aoutput "${ainput[@]}"
+  validate_args aoutput aexpected
+  return $?
+}
+
+test_save1()
+{
+  echo "Test: save-config with invalid file"
+  local ainput=("--save-config" ".")
+  local output
+  output=$(config_setup cfg "${ainput[@]}")
+  local expected="ERROR: Cannot write . as invalid file"
+  validate_output "$output" "$expected"
+  return $?
+}
+
+test_save2()
+{
+  echo "Test: save-config with valid file"
+  local fileout="tcf_save2.cfg"
+  remove_save_file "$fileout"
+  local fileexpected="tcf_load2.cfg"
+  # shellcheck disable=SC2178
+  local -n ainput=TEST2
+  local output
+  output=$(config_setup cfg "${ainput[@]}" "--save-config" "$fileout")
+  local expected="Saving configuration to $fileout"
+  validate_output_and_files "$output" "$expected" "$fileout" "$fileexpected"
+  return $?
+}
+
+test_load_save1()
+{
+  echo "Test: load-config and save-config with valid files"
+  local filecfg="tcf_load2.cfg"
+  local fileout="tcf_ls_save1.cfg"
+  remove_save_file "$fileout"
+  local fileexpected="tcf_ls_load1.cfg"
+  local ainput=("--save-config" "$fileout" "--new" "test opt" "--maybe" "--" "--load-config" "$filecfg" "--wildcard" "****")
+  local output
+  output=$(config_setup cfg "${ainput[@]}")
+  local expected
+  expected=$(echo -en "Read configuration from $filecfg\nSaving configuration to $fileout")
+  validate_output_and_files "$output" "$expected" "$fileout" "$fileexpected"
+  return $?
+}
+
+# main
+FAILED=0
+
+test_opts1
+FAILED=$((FAILED + $?))
+test_opts2
+FAILED=$((FAILED + $?))
+test_opts3
+FAILED=$((FAILED + $?))
+test_opts4
+FAILED=$((FAILED + $?))
+test_load1
+FAILED=$((FAILED + $?))
+test_load2
+FAILED=$((FAILED + $?))
+test_save1
+FAILED=$((FAILED + $?))
+test_save2
+FAILED=$((FAILED + $?))
+test_load_save1
+FAILED=$((FAILED + $?))
+
+echo "FAILURES: $FAILED"
+exit $FAILED

--- a/lava/lava-job-definitions/shared/macros.jinja2
+++ b/lava/lava-job-definitions/shared/macros.jinja2
@@ -35,7 +35,7 @@
 {% endmacro %}
 
 {# Reusable tests #}
-{% macro avahi_discovery(stage, iteration="") %}
+{% macro avahi_discovery(venv_name, stage, iteration="") %}
     {% include "shared/tests/avahi-discovery.yaml" %}
 {% endmacro %}
 

--- a/lava/lava-job-definitions/shared/templates/base.yaml
+++ b/lava/lava-job-definitions/shared/templates/base.yaml
@@ -32,6 +32,9 @@ metadata:
     td-database: "{{ treasure_database }}"
 {% endif %}
 
+context:
+  kernel_start_message: ""
+
 priority: medium
 visibility: public
 

--- a/lava/lava-job-definitions/shared/templates/bootbomb-recovery.yaml
+++ b/lava/lava-job-definitions/shared/templates/bootbomb-recovery.yaml
@@ -44,6 +44,7 @@
            - oe
          run:
            steps:
+           - set +e
            - cd /lava-lxc
            - dpkg -i imx-usb-loader_0-git20181105.4aa98090-1_amd64.deb
            - lsusb
@@ -51,11 +52,13 @@
            - DEVICE_PATH=$(grep 15a2 /sys/bus/usb/devices/*/idVendor |grep "$LAVA_STORAGE_INFO_0_SATA" |awk '{split($0,a,"/idVendor"); print a[1]}')
            - BUSNUM=$(cat $DEVICE_PATH/busnum)
            - DEVICENUM=$(cat $DEVICE_PATH/devnum)
-           - imx_usb --bus=$BUSNUM --device=$DEVICENUM {{ bootbomb_filename }}
+           - imx_usb --bus=$BUSNUM --device=$DEVICENUM {{ bootbomb_filename }} || lava-test-raise "imx_usb failed"
              # Sleep to allow the bootbomb to start up.
            - sleep 30
            - ls -al $LAVA_STORAGE_INFO_0_BLOCK || lava-test-raise "block device not found"
+           - dmesg -T 
            - bmaptool --quiet copy --bmap /lava-lxc/*.wic.bmap /lava-lxc/*.wic.gz $LAVA_STORAGE_INFO_0_BLOCK || lava-test-raise "recovery flash operation failed"
+           - set -e
 
 - boot:
     namespace: recovery

--- a/lava/lava-job-definitions/shared/templates/pytest-job.yaml
+++ b/lava/lava-job-definitions/shared/templates/pytest-job.yaml
@@ -19,9 +19,9 @@
     namespace: lxc
     definitions:
 
-    {{ macros.avahi_discovery() | indent }}
-
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
+
+    {{ macros.avahi_discovery(venv_name) | indent }}
 
     {{ macros.install_mbl_cli(venv_name) | indent }}
 

--- a/lava/lava-job-definitions/shared/tests/avahi-discovery.yaml
+++ b/lava/lava-job-definitions/shared/tests/avahi-discovery.yaml
@@ -7,3 +7,5 @@
   {% if "mbl-core" in mbl_revisions %}
   revision: {{ mbl_revisions["mbl-core"] }}
   {% endif %}
+  parameters:
+      virtual_env: "{{ venv_name }}"

--- a/lava/lava-job-definitions/testplans/core-components.yaml
+++ b/lava/lava-job-definitions/testplans/core-components.yaml
@@ -12,9 +12,9 @@
 
     definitions:
 
-    {{ macros.avahi_discovery() | indent }}
-
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
+
+    {{ macros.avahi_discovery(venv_name) | indent }}
 
     {{ macros.install_mbl_cli(venv_name) | indent }}
 

--- a/lava/lava-job-definitions/testplans/edge-connected.yaml
+++ b/lava/lava-job-definitions/testplans/edge-connected.yaml
@@ -11,9 +11,9 @@
     namespace: lxc
     definitions:
 
-    {{ macros.avahi_discovery() | indent }}
-
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
+
+    {{ macros.avahi_discovery(venv_name) | indent }}
 
     {{ macros.install_mbl_cli(venv_name) | indent }}
 

--- a/lava/lava-job-definitions/testplans/helloworld-update-pelion.yaml
+++ b/lava/lava-job-definitions/testplans/helloworld-update-pelion.yaml
@@ -11,9 +11,9 @@
     namespace: lxc
     definitions:
 
-    {{ macros.avahi_discovery() | indent }}
-
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
+
+    {{ macros.avahi_discovery(venv_name) | indent }}
 
     {{ macros.install_mbl_cli(venv_name) | indent }}
 

--- a/lava/lava-job-definitions/testplans/helloworld-update.yaml
+++ b/lava/lava-job-definitions/testplans/helloworld-update.yaml
@@ -11,9 +11,9 @@
     namespace: lxc
     definitions:
 
-    {{ macros.avahi_discovery() | indent }}
-
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
+
+    {{ macros.avahi_discovery(venv_name) | indent }}
 
     {{ macros.install_mbl_cli(venv_name) | indent }}
 

--- a/lava/lava-job-definitions/testplans/mbed-crypto.yaml
+++ b/lava/lava-job-definitions/testplans/mbed-crypto.yaml
@@ -1,3 +1,0 @@
-{% extends "shared/templates/pytest-job.yaml" %}
-
-{% set job_name = "mbed-crypto" %}

--- a/lava/lava-job-definitions/testplans/mbl-cli-basic-commands.yaml
+++ b/lava/lava-job-definitions/testplans/mbl-cli-basic-commands.yaml
@@ -11,9 +11,9 @@
     namespace: lxc
     definitions:
 
-    {{ macros.avahi_discovery() | indent }}
-
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
+
+    {{ macros.avahi_discovery(venv_name) | indent }}
 
     {{ macros.install_mbl_cli(venv_name) | indent }}
 

--- a/lava/lava-job-definitions/testplans/provision-mbl.yaml
+++ b/lava/lava-job-definitions/testplans/provision-mbl.yaml
@@ -11,9 +11,9 @@
     namespace: lxc
     definitions:
 
-    {{ macros.avahi_discovery() | indent }}
-
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
+
+    {{ macros.avahi_discovery(venv_name) | indent }}
 
     {{ macros.install_mbl_cli(venv_name) | indent }}
 

--- a/lava/lava-job-definitions/testplans/psa-arch-tests.yaml
+++ b/lava/lava-job-definitions/testplans/psa-arch-tests.yaml
@@ -11,9 +11,9 @@
     namespace: lxc
     definitions:
 
-    {{ macros.avahi_discovery() | indent }}
-
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
+
+    {{ macros.avahi_discovery(venv_name) | indent }}
 
     {{ macros.install_mbl_cli(venv_name) | indent }}
 

--- a/lava/lava-job-definitions/testplans/rootfs-update-pelion.yaml
+++ b/lava/lava-job-definitions/testplans/rootfs-update-pelion.yaml
@@ -11,9 +11,9 @@
     namespace: lxc
     definitions:
 
-    {{ macros.avahi_discovery("pre") | indent }}
-
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
+
+    {{ macros.avahi_discovery(venv_name, "pre") | indent }}
 
     {{ macros.install_mbl_cli(venv_name) | indent }}
 
@@ -25,7 +25,7 @@
 
     {{ macros.rootfs_update("POST_CHECK", "rootfs2", image_url, "PELION", venv_name, rootfs_payload_version) | indent }}
 
-    {{ macros.avahi_discovery("post") | indent }}
+    {{ macros.avahi_discovery(venv_name, "post") | indent }}
 
     {{ macros.delete_certificate(venv_name) | indent }}
 {% endblock testplan %}

--- a/lava/lava-job-definitions/testplans/rootfs-update.yaml
+++ b/lava/lava-job-definitions/testplans/rootfs-update.yaml
@@ -11,9 +11,9 @@
     namespace: lxc
     definitions:
 
-    {{ macros.avahi_discovery("pre") | indent }}
-
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
+
+    {{ macros.avahi_discovery(venv_name, "pre") | indent }}
 
     {{ macros.install_mbl_cli(venv_name) | indent }}
 
@@ -41,5 +41,5 @@
 
     {{ macros.rootfs_update("POST_CHECK", "rootfs2", image_url, "MBL-CLI", venv_name, rootfs_payload_version) | indent }}
 
-    {{ macros.avahi_discovery("post") | indent }}
+    {{ macros.avahi_discovery(venv_name, "post") | indent }}
 {% endblock testplan %}

--- a/lava/lava-job-definitions/testplans/soak-rootfs-update-pelion.yaml
+++ b/lava/lava-job-definitions/testplans/soak-rootfs-update-pelion.yaml
@@ -15,9 +15,9 @@
 
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
 
-    {{ macros.install_mbl_cli(venv_name) | indent }}
+    {{ macros.avahi_discovery(venv_name, "pre") | indent }}
 
-    {{ macros.avahi_discovery("pre") | indent }}
+    {{ macros.install_mbl_cli(venv_name) | indent }}
 
     {{ macros.enable_wifi(venv_name) | indent }}
 
@@ -46,7 +46,7 @@
 
     {{ macros.rootfs_update("POST_CHECK", rootfs, image_url, "PELION", venv_name, rootfs_payload_version, iteration) | indent }}
 
-    {{ macros.avahi_discovery("post", iteration) | indent }}
+    {{ macros.avahi_discovery(venv_name, "post", iteration) | indent }}
 
     # 42600 are 11 hours and 50 minutes.
     {{ macros.sleep(42600, iteration) | indent }}

--- a/lava/lava-job-definitions/testplans/soak-rootfs-update.yaml
+++ b/lava/lava-job-definitions/testplans/soak-rootfs-update.yaml
@@ -15,9 +15,9 @@
 
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
 
-    {{ macros.install_mbl_cli(venv_name) | indent }}
+    {{ macros.avahi_discovery(venv_name, "pre") | indent }}
 
-    {{ macros.avahi_discovery("pre") | indent }}
+    {{ macros.install_mbl_cli(venv_name) | indent }}
 
     {% for iteration in range(iterations) %}
     {% if iteration is divisibleby 2 %}
@@ -54,7 +54,7 @@
     {% endif %}
     {{ macros.rootfs_update("POST_CHECK", rootfs, image_url, "MBL-CLI", venv_name, rootfs_payload_version, iteration) | indent }}
 
-    {{ macros.avahi_discovery("post", iteration) | indent }}
+    {{ macros.avahi_discovery(venv_name, "post", iteration) | indent }}
 
     # 42600 are 11 hours and 50 minutes.
     {{ macros.sleep(42600, iteration) | indent }}

--- a/lava/lava-job-definitions/testplans/swupdate.yaml
+++ b/lava/lava-job-definitions/testplans/swupdate.yaml
@@ -1,0 +1,3 @@
+{% extends "shared/templates/pytest-job.yaml" %}
+
+{% set job_name = "swupdate" %}

--- a/lava/lava-job-definitions/testplans/systemd.yaml
+++ b/lava/lava-job-definitions/testplans/systemd.yaml
@@ -11,9 +11,9 @@
     namespace: lxc
     definitions:
 
-    {{ macros.avahi_discovery() | indent }}
-
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
+
+    {{ macros.avahi_discovery(venv_name) | indent }}
 
     {{ macros.install_mbl_cli(venv_name) | indent }}
 

--- a/lava/lava-job-definitions/testplans/wifi-access.yaml
+++ b/lava/lava-job-definitions/testplans/wifi-access.yaml
@@ -12,9 +12,9 @@
       minutes: 50
     namespace: lxc
     definitions:
-    {{ macros.avahi_discovery() | indent }}
-
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
+
+    {{ macros.avahi_discovery(venv_name) | indent }}
 
     {{ macros.install_mbl_cli(venv_name) | indent }}
 

--- a/lava/lava-job-definitions/testplans/wired-and-wifi.yaml
+++ b/lava/lava-job-definitions/testplans/wired-and-wifi.yaml
@@ -12,9 +12,9 @@
       minutes: 50
     namespace: lxc
     definitions:
-    {{ macros.avahi_discovery() | indent }}
-
     {{ macros.create_python_environment(venv_name, host_download_dir) | indent }}
+
+    {{ macros.avahi_discovery(venv_name) | indent }}
 
     {{ macros.install_mbl_cli(venv_name) | indent }}
 

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -114,9 +114,10 @@ done
 
 To enable testing you will need to create and push 3 "TEST COMMITS" on:
 
-* `mbl-manifest` - change `default.xml` entries of mbl-config & meta-mbl to your maintenance branches
-* `meta-mbl` - change `mbl-linked-repositories.conf` to point your maintenance branch of mbl-core (rather than AUTO-REV)
-* `mbl-jenkins` - change `mbl-pipeline` to point to the maintenance branches for mblToolsBranch, paramsBranch, mblManifestBranch & lavaMblBranch (and any new ones!)
+* `mbl-manifest` - change `default.xml` entries of mbl-config & meta-mbl to your maintenance branches;
+* `meta-mbl` - change `mbl-linked-repositories.conf` setting of 
+SRC_URI_OPTIONS_MBL_CORE_REPO to point your maintenance branch of mbl-core rather than master;
+* `mbl-jenkins` - change `mbl-pipeline` to point to the maintenance branches for the mbl-jenkins-library revision, paramsBranch, mblManifestBranch, mblToolsBranch & lavaMblBranch (and any future ones!).
 
 Label the 3 PRs for these repositories as _DO NOT MERGE_, as you will need to back out the TEST COMMIT on each before merging to master.
 

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -8,7 +8,7 @@ This directory contains the tools necessary to:
 
 It does this by containing two repo manifests of all the repositories to be maintained in MBL and using the repo tool to check them out and act on them:
 
-* `default.xml` - for the master maintenance (only on master)
+* `maintenance.xml` - for the master maintenance (only on master)
 * `release.xml` - for the development branch or release branches
 
 It also contains some helper scripts in `scripts`.
@@ -19,6 +19,7 @@ Note: Some of the repositories may not be public at this time, as this process i
 
 * [Maintenance Directions](#maintenance)
 * [Release Directions](#release)
+* [Development Branches Directions](#development)
 
 <a name="maintenance"/>
 
@@ -34,7 +35,7 @@ Can be done once as a place just to perform all maintenance jobs.
 mkdir MAINTENANCE
 cd MAINTENANCE
 # Get the tools on the dev branch - assumed to be the latest versions
-git clone git@github:ARMmbed/mbl-tools
+git clone git@github:ARMmbed/mbl-tools -b <dev-branch>
 export SCRIPTS=$(pwd)/mbl-tools/maintenance/scripts
 ```
 
@@ -167,13 +168,11 @@ repo forall -c $SCRIPTS/git-sync-tag.bash
 
 Follow these instructions to create a release branch from the current dev branch.
 
-NOTE: A similar flow can be used to create a new dev branch from master (with some tweaks!)
-
 Set up the tools:
 
 ```
 mkdir RELWORKDIR ; cd RELWORKDIR
-git clone git@github.com:ARMmbed/mbl-tools
+git clone git@github.com:ARMmbed/mbl-tools -b <dev-branch>
 export SCRIPTS=$(pwd)/mbl-tools/maintenance/scripts
 ```
 
@@ -185,7 +184,8 @@ $SCRIPTS/git-sync-start.bash --release ${RELVER}.setup
 cd ${RELVER}.setup
 ```
 
-Perform the correct alignment and set up of a pinned release manifest and create a release branch for all the repos:
+Perform the correct alignment and set up of a pinned release manifest, which can be copied from the last known good
+development branch build, and create a release branch for all the repos:
 
 ```
 $SCRIPTS/git-sync-manifest.bash pinned-manifest.xml $RELVER
@@ -196,7 +196,7 @@ Now we need to do the tweaks to the following repos:
 
 * `mbl-manifest` - commit `default.xml` with changes done by manifest script
 * `mbl-tools` - edit/commit `maintenance/release.xml` to set the default revision to `mbl-os-x.y` (this is important for the release tagging later!)
-* `mbl-jenkins` - edit/commit `mbl-pipeline` to use `mbl-os-x.y` branches for everything (tools, manifest, lava etc)
+* `mbl-jenkins` - edit/commit `mbl-*pipeline` to use `mbl-os-x.y` branches for everything (tools, manifest, lava etc)
 * `meta-mbl` - edit/commit `meta-mbl-distro/conf/distro/include/mbl-distro.inc` to set `DISTRO_VERSION` to `mbl-os-x.y.z` (NOTE: `z` version!)
 
 Next you can push all the changes to github (this skips the PR flow for the changes done):
@@ -275,3 +275,51 @@ Next create the tags and push them:
 repo forall -c git tag $RELTAG
 repo forall -c git push origin $RELTAG
 ```
+
+<a name="development"/>
+
+## Development Branch directions
+
+### Development branches creation
+
+Follow these instructions to create a development branch from the master branch.
+
+Set up the tools:
+
+```
+mkdir DEVWORKDIR ; cd DEVWORKDIR
+git clone git@github.com:ARMmbed/mbl-tools -b master
+export SCRIPTS=$(pwd)/mbl-tools/maintenance/scripts
+```
+
+Create the checkout of all the repos, replacing `yocto-version-name-dev` with the version to be released (e.g. `warrior-dev`):
+
+```
+export DEVBR=yocto-version-name-dev
+$SCRIPTS/git-sync-start.bash --development ${DEVBR}.setup
+cd ${DEVBR}.setup
+```
+
+Perform the correct alignment and set up of the default.xml manifest and create the development branch for all the repos:
+
+```
+$SCRIPTS/git-sync-manifest.bash armmbed/mbl-manifest/default.xml $DEVBR
+repo start $DEVBR --all
+cd armmbed
+```
+
+Now we need to do the tweaks to the following repos:
+
+1. `mbl-manifest` - edit/commit `default.xml` with changes done by manifest script.
+    1. Change the default revision ( \<default revision="master" sync-j="4"/> line) to `yocto-version-name`
+    1. Some layers may not have the `yocto-version-name` branch and in this case for each project add a specific SHA. And as soon as these projects create the `yocto-version-name` branch, remove the custom `revision=` setting from the `default.xml`
+2. `mbl-tools` - edit/commit `maintenance/release.xml` to set the default revision to `yocto-version-name-dev`
+3. `mbl-jenkins` - edit/commit `mbl-*pipeline` to use `yocto-version-name-dev` branches for everything (tools, manifest, lava etc)
+
+Next you can push all the changes to github (this skips the PR flow for the changes done):
+
+```
+repo forall -p -c git push --set-upstream origin $DEVBR
+```
+
+Now create the Jenkins job to test these new branches.

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -35,7 +35,7 @@ Can be done once as a place just to perform all maintenance jobs.
 mkdir MAINTENANCE
 cd MAINTENANCE
 # Get the tools on the dev branch - assumed to be the latest versions
-git clone git@github:ARMmbed/mbl-tools -b <dev-branch>
+git clone git@github.com:ARMmbed/mbl-tools -b <dev-branch>
 export SCRIPTS=$(pwd)/mbl-tools/maintenance/scripts
 ```
 

--- a/maintenance/scripts/git-sync-diff.bash
+++ b/maintenance/scripts/git-sync-diff.bash
@@ -4,14 +4,38 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-if [ "$1" == "-h" ]; then
+usage()
+{
     echo "Review the outstanding commits from the current branch synchonization"
     echo "Outputs the list of commits in oldest first order"
     echo "Note: requires branches to have been properly tagged via git-sync-tag.bash"
     echo "Note: must use remote (e.g. origin) in branches"
-    echo "Usage: $(basename "$0") [REMOTE_BRANCH_FROM] [REMOTE_BRANCH_TO]"
+    echo "Note: use --no-tag to review more commits, in case of bad maintenance tags"
+    echo "Note: use --no-date to not show dates of the commits"
+    echo "Usage: $(basename "$0") [--no-tag] [--no-date] [REMOTE_BRANCH_FROM] [REMOTE_BRANCH_TO]"
     exit 0
-fi
+}
+
+NO_TAG=0
+COMMIT_DATE=1
+while [ $# -gt 0 ]; do
+    case $1 in
+    --no-tag)
+        NO_TAG=1
+        ;;
+    --no-date)
+        COMMIT_DATE=0
+        ;;
+    --help|-h)
+        usage
+        ;;
+    *)
+        break
+        ;;
+    esac
+    shift
+done
+
 
 REMOTE=$(git remote)
 
@@ -24,27 +48,52 @@ if [ "$DEV" == "" ]; then
 fi
 
 # Print out repo name and settings
-basename "$(git remote get-url "$REMOTE")" .git
+echo "REPO: $(basename "$(git remote get-url "$REMOTE")" .git)"
 echo "BRANCH_FROM=$DEV / BRANCH_TO=$MST"
 
 TAG_TO=$(basename "$DEV")_to_$(basename "$MST")
 
+DATE_COL="\e[36m"
+WARN_COL="\e[31m"
 DEV_COL="\e[32m"
 MST_COL="\e[33m"
 NO_COL="\e[0m"
 
-DIFF=$(git cherry -v --abbrev=7 "$MST" "$DEV" "$TAG_TO")
+if [ $NO_TAG -eq 1 ]; then
+    echo "INFO: NOT stopping at tag $TAG_TO"
+    DIFF=$(git cherry -v --abbrev=7 "$MST" "$DEV")
+else
+    # Get the diff using the tag, but double-check it seems good!
+    ALL_COMMITS=$(git cherry -v --abbrev=7 "$MST" "$DEV" | awk '$0 ~ "^+" {count++} END {print count}')
+    DIFF=$(git cherry -v --abbrev=7 "$MST" "$DEV" "$TAG_TO")
+    TAG_COMMITS=$(printf "%s" "$DIFF" | awk '$0 ~ "^+" {count++} END {print count}')
+    if [ "$ALL_COMMITS" != "$TAG_COMMITS" ]; then
+        echo -e "${WARN_COL}!!!WARNING!!! Tag $TAG_TO maybe incorrect"
+        echo -e "  Tag commits ($TAG_COMMITS) does not match all commits ($ALL_COMMITS)"
+        echo -e "  Please review using --no-tag option${NO_COL}"
+    fi
+fi
 
-echo -e "${MST_COL}${MST} ${DEV_COL}${DEV}${NO_COL}"
+if [ $COMMIT_DATE -eq 1 ]; then
+    CDATE="${DATE_COL}date "
+else
+    CDATE=""
+fi
+
+echo -e "${CDATE}${MST_COL}${MST} ${DEV_COL}${DEV}${NO_COL}"
 
 IFS=$'\n'
 SHAS=""
 for line in $DIFF; do
+    if [ $COMMIT_DATE -eq 1 ]; then
+        CDATE=$(git log -1 --format="%ci" "${line:2:7}")
+        CDATE="${DATE_COL}${CDATE%% *} "
+    fi
     if [[ $line =~ ^\+ ]]; then
-        echo -e "        ${DEV_COL}${line:2}${NO_COL}"
+        echo -e "${CDATE}        ${DEV_COL}${line:2}${NO_COL}"
         SHAS="$SHAS ${line:2:7}"
     elif [[ $line =~ ^- ]]; then
-        echo -e "${MST_COL}${line:2:7}        ${line:9}${NO_COL}"
+        echo -e "${CDATE}${MST_COL}${line:2:7}        ${line:9}${NO_COL}"
     fi
 done
 if [ "$SHAS" != "" ]; then

--- a/maintenance/scripts/git-sync-start.bash
+++ b/maintenance/scripts/git-sync-start.bash
@@ -15,9 +15,15 @@ fi
 # Should be working off master
 MANIFEST=maintenance/maintenance.xml
 RELEASE=0
+DEVELOPMENT=0
 if [ "$1" == "--release" ]; then
     # Should be working off latest dev branch
     RELEASE=1
+    MANIFEST=maintenance/release.xml
+    shift
+elif [ "$1" == "--development" ]; then
+    # Should be working off master
+    DEVELOPMENT=1
     MANIFEST=maintenance/release.xml
     shift
 fi
@@ -80,6 +86,17 @@ if [ $RELEASE -eq 1 ]; then
     echo "$ ${MBL_TOOLS_SCRIPTS_DIR}/git-sync-rc-tag.bash mbl-os-x.y.z-rcn"
     echo "$ repo forall -c git tag new-release-tag"
     echo "$ repo forall -c git push $REMOTE new-release-tag"
+elif [ $DEVELOPMENT -eq 1 ]; then
+    echo "DEVELOPMENT BRANCH flow:"
+    echo "$ ${MBL_TOOLS_SCRIPTS_DIR}/git-sync-manifest.bash armmbed/mbl-manifest/default.xml yocto-version-name-dev"
+    echo "$ repo start yocto-version-name-dev --all"
+    echo "* edit/commit armmbed/mbl-manifest/default.xml with changes done by manifest script."
+    echo "  NOTE: Change the <default revision=\"master\" to yocto-version-name and set a SHA"
+    echo "   revision for the layers that don't yet support the yocto-version-name"
+    echo "* edit/commit armmbed/mbl-tools/maintenance/release.xml to default to yocto-version-name-dev"
+    echo "* edit/commit armmbed/mbl-jenkins/mbl-pipeline to use yocto-version-name-dev"
+    echo "Next you can push all the changes to github (this skips the PR flow for the changes done):"
+    echo "$ repo forall -c push --set-upstream $REMOTE yocto-version-name-dev"
 else
     echo "MAINTENANCE flow:"
     echo "$ repo start new-maintenance-branch --all"

--- a/maintenance/scripts/git-sync-tag.bash
+++ b/maintenance/scripts/git-sync-tag.bash
@@ -34,23 +34,6 @@ TAG_INTO=${DEV}_into_${MST}
 
 set -xe
 
-# Sync master with remote
-git fetch "$REMOTE"
-git checkout "${MST}"
-git pull
-
-# Tagging the last synced commit from the target branch (master branch)
-# Delete on the remote the previous tag
-git push "$REMOTE" :"refs/tags/${TAG_INTO}"
-
-# Delete on the local the previous tag:
-git tag --delete "${TAG_INTO}"
-
-# Tag the <last_target_branch_synced_commit> - ASSUMPTION!
-echo "Tagging ${MST}: $(git log --format=oneline --abbrev-commit -1)"
-git tag "${TAG_INTO}"
-
-
 # Move to dev (but don't update - as assume this is at the right place!)
 git checkout "${DEV}"
 
@@ -64,6 +47,22 @@ git tag --delete "${TAG_TO}"
 # Tag the <last_source_branch_synced_commit> - ASSUMPTION!
 echo "Tagging ${DEV}: $(git log --format=oneline --abbrev-commit -1)"
 git tag "${TAG_TO}"
+
+
+# Sync master with remote
+git checkout "${MST}"
+git pull
+
+# Tagging the last synced commit from the target branch (master branch)
+# Delete on the remote the previous tag
+git push "$REMOTE" :"refs/tags/${TAG_INTO}"
+
+# Delete on the local the previous tag:
+git tag --delete "${TAG_INTO}"
+
+# Tag the <last_target_branch_synced_commit> - ASSUMPTION!
+echo "Tagging ${MST}: $(git log --format=oneline --abbrev-commit -1)"
+git tag "${TAG_INTO}"
 
 
 # Push the tags to the remote

--- a/reports/lava/daily_report.py
+++ b/reports/lava/daily_report.py
@@ -27,7 +27,7 @@ body { background-color: black; }
 table, th, td {
     border:1px solid #669999;
     border-collapse: collapse;
-    font-size: 1.4vw; /* Default size (jobs/tests) */
+    font-size: 1.3vw; /* Default size (jobs/tests) */
     font-family: Arial, Helvetica, sans-serif;
     font-weight: bold;
     padding:5px;
@@ -36,13 +36,14 @@ table, th, td {
 }
 table { min-width: 100%; }
 th { color:#353531; }
-.backamber  { background-color:#cc7a00; }
-.backred    { background-color:#8b0000; }
-.backgreen  { background-color:#006400; }
-.backgrey   { background-color:#808080; }
+.backamber  { background-color:#cc7a00; color:#fff; }
+.backred    { background-color:#8b0000; color:#fff; }
+.backgreen  { background-color:#006400; color:#fff; }
+.backgrey   { background-color:#808080; color:#fff; }
 .textbuild  { font-size: 2vw; } /* Build job header size */
-.textboard  { font-size: 1vw; } /* Board results size */
+.textboard  { font-size: 0.9vw; } /* Board results size */
 .texttime   { float: right; font-size: 0.8vw; color:#fff }
+.textkey    { background-color:#000; color:#fff; font-size: 0.9vw; }
 .textred    { color: #e60000; text-align: right; }
 .textamber  { color: #e68a00; text-align: right; }
 .textgreen  { color: #009900; text-align: right; }
@@ -180,6 +181,52 @@ def get_results_summary(server, submitter, build_name, build_num=-1):
     return summary
 
 
+# List of indicators based for jobs, tests and overall
+# Format for each list entry is:
+# [{"Type": threshold ...}, [positive sym, negative sym, desc]]
+INDICATORS = [
+    [{"Jobs": 0, "Tests": 0, "All": 0}, ["equals", "equals", "Same"]],
+    [{"Jobs": 1, "Tests": 2, "All": 5}, ["#8673", "#8675", "Trivial"]],
+    [{"Jobs": 3, "Tests": 5, "All": 10}, ["uArr", "dArr", "Minor"]],
+    [{"Jobs": 7, "Tests": 10, "All": 20}, ["#10506", "#10507", "Major"]],
+    [{"Jobs": 0, "Tests": 0, "All": 0}, ["#10224", "#10225", "Serious"]],
+]
+
+
+def get_indicator(value, last, prev):
+    """Return an indicator of much different the last and prev results are.
+
+    :return: HTML symbol to indicate how much difference.
+
+    """
+    if value in ["Complete", "Incomplete"]:
+        ind_type = "Jobs"
+    elif value in ["Passed", "Failed"]:
+        ind_type = "Tests"
+    else:
+        ind_type = "All"
+
+    diff = abs(last - prev)
+    index = 0 if last > prev else 1
+    for group in INDICATORS:
+        threshold = group[0][ind_type]
+        indicator = group[1][index]
+        if threshold >= diff:
+            break
+    # Return the last one found
+    return "&{};".format(indicator)
+
+
+def indicator_key_table():
+    """Print out a simple key table of indicators."""
+    print("<table><tr>")
+    for group in INDICATORS:
+        print(
+            '<td class="textkey">&{}; {}</td>'.format(group[1][0], group[1][2])
+        )
+    print("</tr></table>")
+
+
 def compare_runs(runs, value, board=None):
     """Compare a value between runs and return indication of better/worse.
 
@@ -189,16 +236,15 @@ def compare_runs(runs, value, board=None):
     if "Previous" in runs:
         if board:
             last = runs["Last"]["Boards"][board][value]
-            prev = runs["Previous"]["Boards"][board][value]
+            if board in runs["Previous"]["Boards"]:
+                prev = runs["Previous"]["Boards"][board][value]
+            else:
+                # Can't compare as board didn't get run last time
+                return ""
         else:
             last = runs["Last"]["Totals"][value]
             prev = runs["Previous"]["Totals"][value]
-        if last > prev:
-            return "&uArr; "
-        elif last < prev:
-            return "&dArr; "
-        else:
-            return "&equals; "
+        return "{} ".format(get_indicator(value, last, prev))
     else:
         return ""
 
@@ -238,6 +284,55 @@ def get_result_class_and_string(runs, value, board=None):
     return (clss, result)
 
 
+# How much complete/incomplete jobs are worth compared to passed/failed tests
+JOBS_FACTOR = 5
+
+
+def calculate_overall(totals):
+    """Get an overall value from a dictionary of run totals.
+
+    :return: Overall value.
+
+    """
+    result = totals["Complete"] - totals["Incomplete"]
+    result *= JOBS_FACTOR
+    result += totals["Passed"] - totals["Failed"]
+    return result
+
+
+def get_result_overall_class_and_string(runs):
+    """Get a class based on value & the result with comparison indicator.
+
+    :return: Tuple of class and String with status indicator for HTML.
+
+    """
+    totals = runs["Last"]["Totals"]
+    if "Previous" in runs:
+        last = calculate_overall(totals)
+        prev = calculate_overall(runs["Previous"]["Totals"])
+        indicator = " {}".format(get_indicator("All", last, prev))
+    else:
+        last = 0
+        prev = 0
+        indicator = ""
+
+    if totals["Jobs"] > 0:
+        if totals["Incomplete"] == 0 and totals["Failed"] == 0:
+            # Complete success!
+            backclass = "backgreen"
+        elif last < prev:
+            # Things are getting worse!
+            backclass = "backred"
+        else:
+            # Still some problems, but probably getting better.
+            backclass = "backamber"
+    else:
+        # Nothing ran
+        backclass = "backgrey"
+
+    return (backclass, indicator)
+
+
 def html_output(results, link, submitter):
     """Print out all the summary results in HTML tables."""
     print(HTML_HEADER)
@@ -255,21 +350,7 @@ def html_output(results, link, submitter):
         count += 1
 
         # Work out the heading colour based on results
-        if result["Totals"]["Jobs"] > 0:
-            if (
-                result["Totals"]["Incomplete"] == 0
-                and result["Totals"]["Failed"] == 0
-            ):
-                backclass = "backgreen"
-            elif (
-                result["Totals"]["Complete"] == 0
-                and result["Totals"]["Passed"] == 0
-            ):
-                backclass = "backred"
-            else:
-                backclass = "backamber"
-        else:
-            backclass = "backgrey"
+        (backclass, indicator) = get_result_overall_class_and_string(runs)
 
         # Quick link to the detailed results
         anchor = "{}?image_version={}&image_number={}&submitter={}".format(
@@ -281,8 +362,8 @@ def html_output(results, link, submitter):
         header = '<span class="textbuild"><a href="{}">{} build{}</a></span>'.format(  # noqa: E501
             anchor, result["Name"], result["Build"]
         )
-        header = '{}<span class="texttime">{}</span>'.format(
-            header, result["Time"]
+        header = '{}{}<span class="texttime">{}</span>'.format(
+            header, indicator, result["Time"]
         )
         print('<th class="{}" colspan="5">{}</th>'.format(backclass, header))
         print("</tr><tr>")
@@ -356,6 +437,7 @@ def html_output(results, link, submitter):
                 )
             )
         print("</tr></table>")
+    indicator_key_table()
     print("</div>")  # Finish the col
     print("</div>")  # Finish the row
     print(HTML_FOOTER)

--- a/reports/lava/daily_report.py
+++ b/reports/lava/daily_report.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Create daily LAVA report."""
+
+import lavaResultExtract as lRE
+import sys
+from os import environ
+import argparse
+
+HELP_TEXT = """Lava daily report generator.
+Requires the following environment variables to be set:
+  LAVA_SERVER - hostname of the server
+  LAVA_USER   - username of login to server
+  LAVA_TOKEN  - token used by username to login to server
+  REPORT_LINK - URL of Lava report generation script
+"""
+
+HTML_HEADER = """
+<head>
+<style>
+body { background-color: black; }
+table, th, td {
+    border:1px solid #bbbbbb;
+    border-collapse: collapse;
+    font-size: 1.5vw;
+    font-family: Arial, Helvetica, sans-serif;
+    padding:5px;
+    text-shadow:1px 1px 1px #000066;
+    border-bottom:3px solid #669999;
+    background-color:#737373
+}
+table { min-width: 100%; }
+th { color:#fff; }
+.backamber  { background-color:#804d00; }
+.backred    { background-color:#8b0000; }
+.backgreen  { background-color:#006400; }
+.backgrey   { background-color:#808080; }
+.textbuild  { font-size: 2vw; }
+.textred    { color: #8b0000; text-align: right; }
+.textamber  { color: #804d00; text-align: right; }
+.textgreen  { color: #006400; text-align: right; }
+.textblack  { color: #353531; text-align: right; }
+.textboard  { font-size: 1vw; }
+.row { display: flex; }
+.column { flex: 50%; }
+a:link { text-decoration: none; color:#fff; }
+a:visited { text-decoration: none; color:#fff; }
+a:hover { text-decoration: underline; }
+a:active { text-decoration: underline; }
+</style>
+</head>
+<body>
+"""
+
+HTML_FOOTER = """
+</body>
+"""
+
+
+def get_results_summary(server, submitter, build_name):
+    """Get a summary of the jobs/tests for a build.
+
+    :return: Summary dictionary
+
+    """
+    # Get test jobs for the given jenkins build_name
+    query = lRE.get_custom_query(
+        server, submitter, "{}_build-1".format(build_name)
+    )
+    results = server.results.make_custom_query("testjob", query, 100)
+    build_num = query[query.rfind("build") :]
+
+    summary = {
+        "Name": build_name,
+        "Build": build_num,
+        "Totals": {},
+        "Boards": {},
+    }
+    summary["Totals"] = {
+        "Jobs": len(results),
+        "Complete": 0,
+        "Pending": 0,
+        "Suites": 0,
+        "Failed": 0,
+        "Passed": 0,
+    }
+
+    for result in results:
+        # print( result['id'] )
+
+        board = result["requested_device_type_id"]
+        if board not in summary["Boards"]:
+            summary["Boards"][board] = {
+                "Jobs": 0,
+                "Complete": 0,
+                "Pending": 0,
+                "Suites": 0,
+                "Failed": 0,
+                "Passed": 0,
+            }
+
+        details = server.scheduler.job_details(result["id"])
+        if details["status"] == "Complete":
+            summary["Boards"][board]["Complete"] += 1
+            summary["Totals"]["Complete"] += 1
+        elif details["status"] != "Incomplete":
+            summary["Boards"][board]["Pending"] += 1
+            summary["Totals"]["Pending"] += 1
+
+        summary["Boards"][board]["Jobs"] += 1
+
+        suites = lRE.get_testjob_suites_list(server, result["id"])
+
+        for suite in suites:
+            numberOfTests = 0
+            numberOfPasses = 0
+            numberOfFails = 0
+            numberOfSkips = 0
+
+            if suite["name"] != "lava":
+                summary["Boards"][board]["Suites"] += 1
+                summary["Totals"]["Suites"] += 1
+                test_results = lRE.get_testsuite_results(
+                    server, result["id"], suite["name"]
+                )
+                for item in test_results:
+                    numberOfTests += 1
+                    if item["result"] == "pass":
+                        numberOfPasses += 1
+                    elif item["result"] == "skip":
+                        numberOfSkips += 1
+                    elif item["result"] == "fail":
+                        numberOfFails += 1
+                summary["Totals"]["Failed"] += numberOfFails
+                summary["Totals"]["Passed"] += numberOfPasses
+                summary["Boards"][board]["Failed"] += numberOfFails
+                summary["Boards"][board]["Passed"] += numberOfPasses
+
+    return summary
+
+
+def choose_class(result, zero_class, nonz_class):
+    """Return one of the classes based on the result.
+
+    :return: zero_class when zero result, else nonz_class
+
+    """
+    if result == 0:
+        return zero_class
+    else:
+        return nonz_class
+
+
+def html_output(results, link, submitter):
+    """Print out all the summary results in HTML tables."""
+    print(HTML_HEADER)
+
+    print('<div class="row">')
+    half = int((len(results) + 1) / 2)
+    count = 0
+    print('<div class="column">')
+    for result in results:
+        if count == half:
+            print("</div>")  # Finish the col
+            print('<div class="column">')
+        count += 1
+        failed = (
+            result["Totals"]["Jobs"]
+            - result["Totals"]["Complete"]
+            - result["Totals"]["Pending"]
+        )
+        if result["Totals"]["Jobs"] > 0:
+            if failed == 0 and result["Totals"]["Failed"] == 0:
+                backclass = "backgreen"
+            elif (
+                result["Totals"]["Complete"] == 0
+                and result["Totals"]["Failed"] == 0
+            ):
+                backclass = "backred"
+            else:
+                backclass = "backamber"
+        else:
+            backclass = "backgrey"
+
+        anchor = "{}?image_version={}&image_number={}&submitter={}".format(
+            link, result["Name"], result["Build"][5:], submitter
+        )
+
+        print("<table><tr>")
+        print(
+            '<th class="textbuild {}" colspan="5"><a href="{}">{} {}</a></th>'.format(  # noqa: E501
+                backclass, anchor, result["Name"], result["Build"]
+            )
+        )
+        print("</tr><tr>")
+        if result["Totals"]["Pending"] > 0:
+            print("<th>Jobs (pending)</th>")
+            print(
+                '<td class="textamber">{}</td>'.format(
+                    result["Totals"]["Pending"]
+                )
+            )
+            span = "1"
+        else:
+            print("<th>Jobs</th>")
+            span = "2"
+        print(
+            '<td class="{}" colspan="{}">{}</td>'.format(
+                choose_class(
+                    result["Totals"]["Complete"], "textblack", "textgreen"
+                ),
+                span,
+                result["Totals"]["Complete"],
+            )
+        )
+        print(
+            '<td class="{}" colspan="2">{}</td>'.format(
+                choose_class(failed, "textblack", "textred"), failed
+            )
+        )
+        print("</tr><tr>")
+        print("<th>Tests</th>")
+        print(
+            '<td class="{}" colspan="2">{}</td>'.format(
+                choose_class(
+                    result["Totals"]["Passed"], "textblack", "textgreen"
+                ),
+                result["Totals"]["Passed"],
+            )
+        )
+        print(
+            '<td class="{}" colspan="2">{}</td>'.format(
+                choose_class(
+                    result["Totals"]["Failed"], "textblack", "textred"
+                ),
+                result["Totals"]["Failed"],
+            )
+        )
+        for board, info in result["Boards"].items():
+            print("</tr><tr>")
+            print('<th class="textboard">{} (jobs/tests)</th>'.format(board))
+            print(
+                '<td class="textboard {}">{}</td>'.format(
+                    choose_class(info["Complete"], "textblack", "textgreen"),
+                    info["Complete"],
+                )
+            )
+            failed = info["Jobs"] - info["Complete"] - info["Pending"]
+            print(
+                '<td class="textboard {}">{}</td>'.format(
+                    choose_class(failed, "textblack", "textred"), failed
+                )
+            )
+            print(
+                '<td class="textboard {}">{}</td>'.format(
+                    choose_class(info["Passed"], "textblack", "textgreen"),
+                    info["Passed"],
+                )
+            )
+            print(
+                '<td class="textboard {}">{}</td>'.format(
+                    choose_class(info["Failed"], "textblack", "textred"),
+                    info["Failed"],
+                )
+            )
+        print("</tr></table>")
+    print("</div>")  # Finish the col
+    print("</div>")  # Finish the row
+    print(HTML_FOOTER)
+
+
+def main():
+    """Create the daily report."""
+    parser = argparse.ArgumentParser(
+        description=HELP_TEXT, formatter_class=argparse.RawTextHelpFormatter
+    )
+    parser.add_argument(
+        "--submitter",
+        type=str,
+        default="mbl",
+        nargs=None,
+        help="Submitter (default: mbl)",
+    )
+    parser.add_argument(
+        "build_name", nargs="+", help="List of build names from jenkins"
+    )
+    args = parser.parse_args()
+
+    try:
+        server = lRE.connect_to_server(
+            environ["LAVA_SERVER"], environ["LAVA_USER"], environ["LAVA_TOKEN"]
+        )
+        link = environ["REPORT_LINK"]
+    except KeyError as key:
+        print("ERROR: unset environment variable - {}".format(key))
+        exit(2)
+
+    results = []
+    for build in args.build_name:
+        results.append(get_results_summary(server, args.submitter, build))
+
+    html_output(results, link, args.submitter)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reports/lava/daily_report.py
+++ b/reports/lava/daily_report.py
@@ -24,25 +24,25 @@ HTML_HEADER = """
 <style>
 body { background-color: black; }
 table, th, td {
-    border:1px solid #bbbbbb;
+    border:1px solid #669999;
     border-collapse: collapse;
     font-size: 1.5vw;
     font-family: Arial, Helvetica, sans-serif;
+    font-weight: bold;
     padding:5px;
-    text-shadow:1px 1px 1px #000066;
     border-bottom:3px solid #669999;
-    background-color:#737373
+    background-color:#f2f2f2;
 }
 table { min-width: 100%; }
-th { color:#fff; }
-.backamber  { background-color:#804d00; }
+th { color:#353531; }
+.backamber  { background-color:#cc7a00; }
 .backred    { background-color:#8b0000; }
 .backgreen  { background-color:#006400; }
 .backgrey   { background-color:#808080; }
 .textbuild  { font-size: 2vw; }
-.textred    { color: #8b0000; text-align: right; }
+.textred    { color: #e60000; text-align: right; }
 .textamber  { color: #804d00; text-align: right; }
-.textgreen  { color: #006400; text-align: right; }
+.textgreen  { color: #009900; text-align: right; }
 .textblack  { color: #353531; text-align: right; }
 .textboard  { font-size: 1vw; }
 .row { display: flex; }

--- a/reports/lava/daily_report.py
+++ b/reports/lava/daily_report.py
@@ -10,6 +10,7 @@ import lavaResultExtract as lRE
 import sys
 from os import environ
 import argparse
+from datetime import datetime
 
 HELP_TEXT = """Lava daily report generator.
 Requires the following environment variables to be set:
@@ -26,7 +27,7 @@ body { background-color: black; }
 table, th, td {
     border:1px solid #669999;
     border-collapse: collapse;
-    font-size: 1.5vw;
+    font-size: 1.4vw; /* Default size (jobs/tests) */
     font-family: Arial, Helvetica, sans-serif;
     font-weight: bold;
     padding:5px;
@@ -39,12 +40,13 @@ th { color:#353531; }
 .backred    { background-color:#8b0000; }
 .backgreen  { background-color:#006400; }
 .backgrey   { background-color:#808080; }
-.textbuild  { font-size: 2vw; }
+.textbuild  { font-size: 2vw; } /* Build job header size */
+.textboard  { font-size: 1vw; } /* Board results size */
+.texttime   { float: right; font-size: 0.8vw; color:#fff }
 .textred    { color: #e60000; text-align: right; }
-.textamber  { color: #804d00; text-align: right; }
+.textamber  { color: #e68a00; text-align: right; }
 .textgreen  { color: #009900; text-align: right; }
 .textblack  { color: #353531; text-align: right; }
-.textboard  { font-size: 1vw; }
 .row { display: flex; }
 .column { flex: 50%; }
 a:link { text-decoration: none; color:#fff; }
@@ -60,8 +62,34 @@ HTML_FOOTER = """
 </body>
 """
 
+MAX_RESULTS = 100
 
-def get_results_summary(server, submitter, build_name):
+
+def get_relative_time(timestamp):
+    """Given a timestamp string, get a relative time.
+
+    :return: Human readable relative time.
+
+    """
+    dt = datetime.strptime(timestamp, "%Y%m%dT%H:%M:%S")
+    delta = datetime.now() - dt
+    days = delta.days
+    relative = ""
+    if days != 0:
+        relative = "{} day{} ago".format(days, ("" if days == 1 else "s"))
+    else:
+        mins = int(delta.seconds / 60)
+        if mins < 100:
+            relative = "{} min{} ago".format(mins, ("" if mins == 1 else "s"))
+        else:
+            hours = int(delta.seconds / 3600)
+            relative = "{} hour{} ago".format(
+                hours, ("" if hours == 1 else "s")
+            )
+    return relative
+
+
+def get_results_summary(server, submitter, build_name, build_num=-1):
     """Get a summary of the jobs/tests for a build.
 
     :return: Summary dictionary
@@ -69,35 +97,41 @@ def get_results_summary(server, submitter, build_name):
     """
     # Get test jobs for the given jenkins build_name
     query = lRE.get_custom_query(
-        server, submitter, "{}_build-1".format(build_name)
+        server, submitter, "{}_build{}".format(build_name, build_num)
     )
-    results = server.results.make_custom_query("testjob", query, 100)
-    build_num = query[query.rfind("build") :]
+    results = server.results.make_custom_query("testjob", query, MAX_RESULTS)
+    build_num = query[query.rfind("build") + 5 :]
+
+    if len(results) > 0:
+        time = get_relative_time(results[0]["submit_time"].value)
+    else:
+        time = "never"
 
     summary = {
         "Name": build_name,
         "Build": build_num,
         "Totals": {},
         "Boards": {},
+        "Time": time,
     }
     summary["Totals"] = {
         "Jobs": len(results),
         "Complete": 0,
         "Pending": 0,
+        "Incomplete": 0,
         "Suites": 0,
         "Failed": 0,
         "Passed": 0,
     }
 
     for result in results:
-        # print( result['id'] )
-
         board = result["requested_device_type_id"]
         if board not in summary["Boards"]:
             summary["Boards"][board] = {
                 "Jobs": 0,
                 "Complete": 0,
                 "Pending": 0,
+                "Incomplete": 0,
                 "Suites": 0,
                 "Failed": 0,
                 "Passed": 0,
@@ -107,7 +141,10 @@ def get_results_summary(server, submitter, build_name):
         if details["status"] == "Complete":
             summary["Boards"][board]["Complete"] += 1
             summary["Totals"]["Complete"] += 1
-        elif details["status"] != "Incomplete":
+        elif details["status"] in ["Incomplete", "Canceled"]:
+            summary["Boards"][board]["Incomplete"] += 1
+            summary["Totals"]["Incomplete"] += 1
+        else:
             summary["Boards"][board]["Pending"] += 1
             summary["Totals"]["Pending"] += 1
 
@@ -143,6 +180,29 @@ def get_results_summary(server, submitter, build_name):
     return summary
 
 
+def compare_runs(runs, value, board=None):
+    """Compare a value between runs and return indication of better/worse.
+
+    :return: HTML symbol to indicate status.
+
+    """
+    if "Previous" in runs:
+        if board:
+            last = runs["Last"]["Boards"][board][value]
+            prev = runs["Previous"]["Boards"][board][value]
+        else:
+            last = runs["Last"]["Totals"][value]
+            prev = runs["Previous"]["Totals"][value]
+        if last > prev:
+            return "&uArr; "
+        elif last < prev:
+            return "&dArr; "
+        else:
+            return "&equals; "
+    else:
+        return ""
+
+
 def choose_class(result, zero_class, nonz_class):
     """Return one of the classes based on the result.
 
@@ -155,6 +215,29 @@ def choose_class(result, zero_class, nonz_class):
         return nonz_class
 
 
+def get_result_class_and_string(runs, value, board=None):
+    """Get a class based on value & the result with comparison indicator.
+
+    :return: Tuple of class - zero_class when zero result, else nonz_class,
+    and String with status indicator for HTML.
+
+    """
+    if board:
+        result = runs["Last"]["Boards"][board][value]
+    else:
+        result = runs["Last"]["Totals"][value]
+
+    if value in ["Complete", "Passed"]:
+        clss = choose_class(result, "textblack", "textgreen")
+    elif value in ["Incomplete", "Failed"]:
+        clss = choose_class(result, "textblack", "textred")
+    else:
+        clss = "textamber"
+
+    result = "{}{}".format(compare_runs(runs, value, board), result)
+    return (clss, result)
+
+
 def html_output(results, link, submitter):
     """Print out all the summary results in HTML tables."""
     print(HTML_HEADER)
@@ -163,22 +246,24 @@ def html_output(results, link, submitter):
     half = int((len(results) + 1) / 2)
     count = 0
     print('<div class="column">')
-    for result in results:
+    for runs in results:
+        result = runs["Last"]
+        # Put half the jobs in one column and the others in another
         if count == half:
             print("</div>")  # Finish the col
             print('<div class="column">')
         count += 1
-        failed = (
-            result["Totals"]["Jobs"]
-            - result["Totals"]["Complete"]
-            - result["Totals"]["Pending"]
-        )
+
+        # Work out the heading colour based on results
         if result["Totals"]["Jobs"] > 0:
-            if failed == 0 and result["Totals"]["Failed"] == 0:
+            if (
+                result["Totals"]["Incomplete"] == 0
+                and result["Totals"]["Failed"] == 0
+            ):
                 backclass = "backgreen"
             elif (
                 result["Totals"]["Complete"] == 0
-                and result["Totals"]["Failed"] == 0
+                and result["Totals"]["Passed"] == 0
             ):
                 backclass = "backred"
             else:
@@ -186,85 +271,88 @@ def html_output(results, link, submitter):
         else:
             backclass = "backgrey"
 
+        # Quick link to the detailed results
         anchor = "{}?image_version={}&image_number={}&submitter={}".format(
-            link, result["Name"], result["Build"][5:], submitter
+            link, result["Name"], result["Build"], submitter
         )
 
+        # Start the table with a main job name heading
         print("<table><tr>")
-        print(
-            '<th class="textbuild {}" colspan="5"><a href="{}">{} {}</a></th>'.format(  # noqa: E501
-                backclass, anchor, result["Name"], result["Build"]
-            )
+        header = '<span class="textbuild"><a href="{}">{} build{}</a></span>'.format(  # noqa: E501
+            anchor, result["Name"], result["Build"]
         )
+        header = '{}<span class="texttime">{}</span>'.format(
+            header, result["Time"]
+        )
+        print('<th class="{}" colspan="5">{}</th>'.format(backclass, header))
         print("</tr><tr>")
+        # Indicate there are still jobs pending
         if result["Totals"]["Pending"] > 0:
             print("<th>Jobs (pending)</th>")
-            print(
-                '<td class="textamber">{}</td>'.format(
-                    result["Totals"]["Pending"]
-                )
-            )
             span = "1"
         else:
-            print("<th>Jobs</th>")
-            span = "2"
+            if (
+                "Previous" in runs
+                and runs["Previous"]["Totals"]["Pending"] > 0
+            ):
+                print("<th>Jobs (previous pends)</th>")
+                span = "1"
+            else:
+                print("<th>Jobs</th>")
+                span = "2"
+        if span == "1":
+            print(
+                '<td class="{}">{}</td>'.format(
+                    *get_result_class_and_string(runs, "Pending")
+                )
+            )
+
+        # Overall job stats
         print(
-            '<td class="{}" colspan="{}">{}</td>'.format(
-                choose_class(
-                    result["Totals"]["Complete"], "textblack", "textgreen"
-                ),
-                span,
-                result["Totals"]["Complete"],
+            '<td colspan="{}" class="{}">{}</td>'.format(
+                span, *get_result_class_and_string(runs, "Complete")
             )
         )
         print(
-            '<td class="{}" colspan="2">{}</td>'.format(
-                choose_class(failed, "textblack", "textred"), failed
+            '<td colspan="2" class="{}">{}</td>'.format(
+                *get_result_class_and_string(runs, "Incomplete")
             )
         )
         print("</tr><tr>")
+        # Overall test stats
         print("<th>Tests</th>")
         print(
-            '<td class="{}" colspan="2">{}</td>'.format(
-                choose_class(
-                    result["Totals"]["Passed"], "textblack", "textgreen"
-                ),
-                result["Totals"]["Passed"],
+            '<td colspan="2" class="{}">{}</td>'.format(
+                *get_result_class_and_string(runs, "Passed")
             )
         )
         print(
-            '<td class="{}" colspan="2">{}</td>'.format(
-                choose_class(
-                    result["Totals"]["Failed"], "textblack", "textred"
-                ),
-                result["Totals"]["Failed"],
+            '<td colspan="2" class="{}">{}</td>'.format(
+                *get_result_class_and_string(runs, "Failed")
             )
         )
+        # Per board stats
         for board, info in result["Boards"].items():
             print("</tr><tr>")
             print('<th class="textboard">{} (jobs/tests)</th>'.format(board))
             print(
                 '<td class="textboard {}">{}</td>'.format(
-                    choose_class(info["Complete"], "textblack", "textgreen"),
-                    info["Complete"],
-                )
-            )
-            failed = info["Jobs"] - info["Complete"] - info["Pending"]
-            print(
-                '<td class="textboard {}">{}</td>'.format(
-                    choose_class(failed, "textblack", "textred"), failed
+                    *get_result_class_and_string(runs, "Complete", board)
                 )
             )
             print(
                 '<td class="textboard {}">{}</td>'.format(
-                    choose_class(info["Passed"], "textblack", "textgreen"),
-                    info["Passed"],
+                    *get_result_class_and_string(runs, "Incomplete", board)
                 )
             )
             print(
                 '<td class="textboard {}">{}</td>'.format(
-                    choose_class(info["Failed"], "textblack", "textred"),
-                    info["Failed"],
+                    *get_result_class_and_string(runs, "Passed", board)
+                )
+            )
+            print(
+                '<td class="textboard {}">{}</td>'.format(
+                    *get_result_class_and_string(runs, "Failed", board)
                 )
             )
         print("</tr></table>")
@@ -301,7 +389,15 @@ def main():
 
     results = []
     for build in args.build_name:
-        results.append(get_results_summary(server, args.submitter, build))
+        runs = {}
+        runs["Last"] = get_results_summary(server, args.submitter, build)
+        if runs["Last"]["Build"]:
+            build_num = int(runs["Last"]["Build"]) - 1
+            if build_num > 0:
+                runs["Previous"] = get_results_summary(
+                    server, args.submitter, build, build_num
+                )
+        results.append(runs)
 
     html_output(results, link, args.submitter)
 

--- a/reports/lava/lavaResultExtract.py
+++ b/reports/lava/lavaResultExtract.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Parse LAVA results."""
+
+import argparse
+import sys
+import xmlrpc.client
+import yaml
+
+
+outputBuffer = []
+
+
+def connect_to_server(hostname, username, token):
+    """Connect to the Lava server.
+
+    :return: server object
+
+    """
+    server = xmlrpc.client.ServerProxy(
+        "http://%s:%s@%s/RPC2" % (username, token, hostname), allow_none=True
+    )
+    return server
+
+
+def setup_parser():
+    """Create command line parser.
+
+    :return: parser object.
+
+    """
+    parser = argparse.ArgumentParser(description="Extract Lava Results")
+    parser.add_argument(
+        "--server",
+        type=str,
+        default="lava.mbedcloudtesting.com",
+        nargs="?",
+        help="Lava server name",
+    )
+    parser.add_argument(
+        "--user", type=str, nargs="?", help="Lava username", required=True
+    )
+    parser.add_argument(
+        "--token", type=str, nargs="?", help="Lava API token", required=True
+    )
+    parser.add_argument(
+        "--tag",
+        type=str,
+        default="mbl-os-0.6.1-rc2_build2",
+        nargs="?",
+        help="Build tag",
+    )
+    parser.add_argument(
+        "--numResults",
+        type=int,
+        default="100",
+        nargs="?",
+        help="Number of Results",
+    )
+    parser.add_argument(
+        "--submitter", type=str, default="mbl", nargs="?", help="Submitter"
+    )
+    parser.add_argument(
+        "--lava_query", type=str, default="", nargs="?", help="Lava Query"
+    )
+    parser.add_argument(
+        "--sort", type=str, default="", nargs="?", help="Sort type"
+    )
+    parser.add_argument(
+        "--query_owner",
+        type=str,
+        default="",
+        nargs="?",
+        help="Lava query owner",
+    )
+    parser.add_argument(
+        "--fail",
+        type=str,
+        default="false",
+        nargs="?",
+        help="Set to true to show only failed results",
+    )
+    return parser
+
+
+def get_testjob_suites_list(server, id):
+    """Get lava suites of test job id.
+
+    :return: dictionary of suites.
+
+    """
+    return yaml.load(
+        server.results.get_testjob_suites_list_yaml(id), yaml.BaseLoader
+    )
+
+
+def get_testsuite_results(server, id, name):
+    """Get lava results of test suite in job id.
+
+    :return: dictionary of results.
+
+    """
+    return yaml.load(
+        server.results.get_testsuite_results_yaml(id, name), yaml.BaseLoader
+    )
+
+
+def print_result(result, server, hostname, show_failures_only):
+    """Print out the test jobs results as html output."""
+    tempBuffer = []
+    failure_detected = False
+
+    if server.scheduler.job_details(result["id"])["status"] != "Complete":
+        failure_detected = True
+        color = "red"
+    else:
+        color = "black"
+
+    tempBuffer.append("<table>")
+    tempBuffer.append('<col width="350">')
+    tempBuffer.append('<col width="150">')
+    tempBuffer.append('<col width="100">')
+    tempBuffer.append('<col width="100">')
+    tempBuffer.append('<col width="100">')
+
+    try:
+        worker = server.scheduler.devices.show(result["actual_device_id"])[
+            "worker"
+        ].split(".")[0]
+    except xmlrpc.client.Fault as e:
+        worker = "nowhere"
+
+    tempBuffer.append(
+        "<br><b>{} on {}</b>\n".format(
+            result["description"], result["requested_device_type_id"]
+        )
+    )
+
+    tempBuffer.append(
+        'Job <a href="https://{}/scheduler/job/{}">{}</a> Status: <font color="{}">{}</font> on device <i>{}</i>, worker <i>{}</i>. Submitted by <i>{}</i> \n'.format(  # noqa: E501
+            hostname,
+            result["id"],
+            result["id"],
+            color,
+            server.scheduler.job_details(result["id"])["status"],
+            result["actual_device_id"],
+            worker,
+            server.scheduler.job_details(result["id"])["submitter_username"],
+        )
+    )
+
+    tempBuffer.append("<tr></tr>")
+
+    tempBuffer.append(
+        "<tr><th>Suite</th><th>Number Of Tests</th><th>Pass</th><th>Fail</th><th>Skip</th></tr>\n"  # noqa: E501
+    )
+
+    suites = get_testjob_suites_list(server, result["id"])
+
+    for suite in suites:
+        numberOfTests = 0
+        numberOfPasses = 0
+        numberOfFails = 0
+        numberOfSkips = 0
+
+        if suite["name"] != "lava":
+            test_results = get_testsuite_results(
+                server, result["id"], suite["name"]
+            )
+            for item in test_results:
+                numberOfTests += 1
+                if item["result"] == "pass":
+                    numberOfPasses += 1
+                elif item["result"] == "skip":
+                    numberOfSkips += 1
+                elif item["result"] == "fail":
+                    numberOfFails += 1
+                    failure_detected = True
+                else:
+                    tempBuffer.append(item)
+            if numberOfSkips == 0:
+                skipColor = "black"
+            else:
+                skipColor = "orange"
+            if numberOfFails == 0:
+                failColor = "black"
+            else:
+                failColor = "red"
+
+            tempBuffer.append(
+                '<tr><td>{}</td><td>{}</td><td>{}</td><td><font color="{}">{}</font></td><td><font color="{}">{}</font></td><tr>'.format(  # noqa: E501
+                    suite["name"],
+                    numberOfTests,
+                    numberOfPasses,
+                    failColor,
+                    numberOfFails,
+                    skipColor,
+                    numberOfSkips,
+                )
+            )
+    tempBuffer.append("</table>")
+
+    if show_failures_only is True:
+        if failure_detected is True:
+            for line in tempBuffer:
+                outputBuffer.append(line)
+    else:
+        for line in tempBuffer:
+            outputBuffer.append(line)
+
+
+def sortResultsByDevice(results):
+    """Sort the lava test jobs by device.
+
+    :return: sorted list
+
+    """
+    sortedResults = sorted(
+        results,
+        key=lambda i: (i["requested_device_type_id"], i["description"]),
+    )
+    return sortedResults
+
+
+def get_custom_query(server, submitter, tag):
+    """Get lava query for test jobs associated with tag.
+
+    :return: query string
+
+    """
+    if submitter == "wild":
+        test_tag = ""
+    else:
+        test_tag = "testjob__submitter__exact__" + submitter + ","
+
+    # If the tag contains -1 then find the first matching job that contains
+    # the build information, less the version number, and then find all of
+    # them containing that version.
+    # Otherwise just use the tag provided.
+    if tag.find("-1") != -1:
+        # Keep the tag up to the "-1"
+        test_tag2 = (
+            "testjob__description__contains__" + tag[0 : tag.find("-1")]
+        )
+        results = server.results.make_custom_query(
+            "testjob", test_tag + test_tag2, 1
+        )
+        if len(results) != 0:
+            test_tag2 = (
+                "testjob__description__contains__"
+                + results[0]["description"].split()[0]
+            )
+    else:
+        test_tag2 = "testjob__description__contains__" + tag
+
+    return test_tag + test_tag2
+
+
+def main():
+    """Perform the main execution."""
+    # Parse command line
+    options = setup_parser().parse_args()
+
+    server = connect_to_server(options.server, options.user, options.token)
+
+    if options.lava_query == "":
+        # Find results from jobs submitted by mbl and containing the provided
+        # build tag
+        query = get_custom_query(server, options.submitter, options.tag)
+        results = server.results.make_custom_query(
+            "testjob", query, options.numResults
+        )
+    else:
+        try:
+            results = server.results.run_query(
+                options.lava_query, options.numResults, options.query_owner
+            )
+        except xmlrpc.client.Fault as e:
+            outputBuffer.append(
+                'Error running Lava query "{}"<br>'.format(options.lava_query)
+            )
+            results = []
+
+    if options.sort == "by_device":
+        results = sortResultsByDevice(results)
+
+    no_failures_found = True
+    show_failures_only = options.fail == "true"
+
+    outputBuffer.append("<head>")
+    outputBuffer.append("<style>")
+    outputBuffer.append("table, th, td {")
+    outputBuffer.append("border: 1px solid black;")
+    outputBuffer.append("border-collapse: collapse;")
+    outputBuffer.append("}")
+    outputBuffer.append("</style>")
+    outputBuffer.append("</head>")
+    outputBuffer.append("<body>")
+
+    if options.lava_query == "":
+        outputBuffer.append(
+            '{} results found for submitter "{}" and build "{}"<br>'.format(
+                len(results), options.submitter, options.tag
+            )
+        )
+    else:
+        outputBuffer.append(
+            '{} results found for lava query "{}" <br>'.format(
+                len(results), options.lava_query
+            )
+        )
+
+    for result in results:
+        # print(result)
+        # print(result['requested_device_type_id'])
+        # print(result['definition'])
+        # print(result['id'])
+        # print(server.results.get_testjob_results_yaml(result['id']))
+        # print(server.results.get_testjob_suites_list_yaml(result['id']))
+
+        no_failures_found = False
+        print_result(result, server, options.server, show_failures_only)
+
+    if show_failures_only and no_failures_found:
+        if options.lava_query == "":
+            outputBuffer.append(
+                'No matching failure results found for submitter "{}" and build "{}"'.format(  # noqa: E501
+                    options.submitter, options.tag
+                )
+            )
+        else:
+            outputBuffer.append(
+                'No matching failure results found for lava query "{}" <br>'.format(  # noqa: E501
+                    options.lava_query
+                )
+            )
+
+    outputBuffer.append("</body>")
+
+    for line in outputBuffer:
+        print(line)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
2019-10-23 a5e341f Minor updates for maintenance flow (#331)
2019-10-23 eee3850 build-update-payloads.py: deal with new payload format (#334)
IGN 2019-10-24 22280b0 Change BSP tests to use pytest. (#335)
IGN 2019-10-24 028d899 Automate board recovery. (#330)
2019-10-25 2235dd9 Lava daily report (#337)
2019-10-28 32b0666 lava:testplans: Add swupdate test plan. (#340)
IGN 2019-10-28 3af15c7 Add error handling. (#342)
2019-10-29 5feb18d Better colours for report readability (#345)
2019-10-29 f153cd9 Maintenance tagging fixes (#338)
2019-10-29 7ce86cf Add job times and indicators versus previous runs (#346)
2019-10-29 0cd8374 Add configuration save/load to run-me.sh (#325)
2019-10-30 804227e Remove duplicate Mbed Crypto test
2019-10-31 1c825e0 Add extra error checking.
2019-11-04 8cd9f8c Fix LAVA pipeline for production images
2019-11-05 558b35b Change avahi-discovery to be a pytest. (#352)
2019-11-06 8d989e6 build-update-payloads.py: add new deps and create testinfo files (#355)
2019-11-07 3b915b1 Add strength indicators to lava report (#349)
2019-11-08 f3d7d4a Change to using HTTPS for default mbl-manifest repo
2019-11-08 99e7656 maintenance: Update documentation for dev branches creation (#357)
2019-11-08 45a31de maintenance/README.md: minor fix for github mbl-tools repo link (#358)

IGN(ored) = Changes that are specific to warrior-dev, e.g. mbl-core revision
MIS(sed) = Old change that seems to have been missed