### PR TITLE
Remove auto-login action from minimal reboot.

### DIFF
--- a/lava/lava-job-definitions/testplans/rootfs-update.yaml
+++ b/lava/lava-job-definitions/testplans/rootfs-update.yaml
@@ -24,11 +24,8 @@
     method: minimal
     # We don't power cycle because the rootfs update has rebooted the DUT
     reset: false
-    auto_login:
-        login_prompt: "mbed-linux-os-(.*) login:"
-        username: root
     prompts:
-        - "root@mbed-linux-os-(.*):~#"
+      - "{{ login_prompt }}"
     timeout:
         minutes: 5
     failure-retry: 3

--- a/lava/lava-job-definitions/testplans/soak-rootfs-update.yaml
+++ b/lava/lava-job-definitions/testplans/soak-rootfs-update.yaml
@@ -32,11 +32,8 @@
     method: minimal
     # We don't power cycle because the rootfs update has rebooted the DUT
     reset: false
-    auto_login:
-        login_prompt: "mbed-linux-os-(.*) login:"
-        username: root
     prompts:
-        - "root@mbed-linux-os-(.*):~#"
+      - "{{ login_prompt }}"
     timeout:
         minutes: 5
     failure-retry: 3


### PR DESCRIPTION
Removed the auto-login action and replaced the prompt to be the login
prompt. This enables Production image testing.

Lava tests of the rootfs-update:
https://lava.mbedcloudtesting.com/scheduler/job/78186
https://lava.mbedcloudtesting.com/scheduler/job/78187
https://lava.mbedcloudtesting.com/scheduler/job/78196
https://lava.mbedcloudtesting.com/scheduler/job/78197
https://lava.mbedcloudtesting.com/scheduler/job/78198
