### PR TITLE
build-update-payloads: Build a multi component payload.

### DIFF
--- a/build/mbl/build-update-payloads.py
+++ b/build/mbl/build-update-payloads.py
@@ -83,7 +83,7 @@ def main():
     # Build the packages
     packages = "virtual/atf optee-os virtual/bootloader virtual/kernel"
     bitbake_build_commands = [
-        "bitbake -c cleansstate {}".format(packages),
+        "bitbake -c cleansstate {} {}".format(packages, args.image),
         "bitbake {}".format(args.image),
     ]
     for command in bitbake_build_commands:
@@ -94,6 +94,7 @@ def main():
     bootloader2_base_path = args.outputdir / "bootloader2_payload"
     kernel_base_path = args.outputdir / "kernel_payload"
     rootfs_base_path = args.outputdir / "rootfs_payload"
+    multi_component_base_path = args.outputdir / "multi_component_payload"
 
     create_update_payload_commands = [
         "create-update-payload -b1 -o {0}.swu -t {0}.testinfo".format(
@@ -107,6 +108,10 @@ def main():
         ),
         "create-update-payload -r {0} -o {1}.swu -t {1}.testinfo".format(
             args.image, rootfs_base_path
+        ),
+        (
+            "create-update-payload -b 1 2 -k -r {0} -o {1}.swu -t {1}"
+            ".testinfo".format(args.image, multi_component_base_path)
         ),
     ]
     for command in create_update_payload_commands:


### PR DESCRIPTION
Tell create-update-payload to build a multi component payload for
testing.

While I'm here, tell bitbake to clean the sstate cache for the image.
This is to ensure the /etc/build file is recreated, as our rootfs
update test will check the mtime of this file and fail if it hasn't
changed since before the update.

Cleaning the cache for mbl-image-development fixes IOTMBL-2633
Creating a multi-component payload is part of IOTMBL-2292

Jenkins: http://jenkins.mbed-linux.arm.com/job/rw-test/177/