### PR TITLE
Improve pico7 recovery mode backport to zeus-dev (#373)

### DIFF
--- a/lava/lava-job-definitions/shared/templates/imx7d-pico-mbl-deploy-boot.yaml
+++ b/lava/lava-job-definitions/shared/templates/imx7d-pico-mbl-deploy-boot.yaml
@@ -1,3 +1,3 @@
 {% extends "shared/templates/bootbomb-recovery.yaml" %}
 
-{% set bootbomb_filename = "pico-imx7d_bootbomb_20170112.imx" %}
+{% set bootbomb_filename = "pico-imx7d_u-boot_20191114.imx" %}


### PR DESCRIPTION
Updated to use a u-boot bootbomb which will be more robust.