### PR TITLE
Increase the numResults default.

### DIFF
--- a/reports/lava/lavaResultExtract.py
+++ b/reports/lava/lavaResultExtract.py
@@ -57,7 +57,7 @@ def setup_parser():
     parser.add_argument(
         "--numResults",
         type=int,
-        default="100",
+        default="1000",
         nargs="?",
         help="Number of Results",
     )


### PR DESCRIPTION
Increased the default from 100 to 1000 - the current maximum number of jobs running on a single build is 120.