### PR TITLE
Modify soak test templates.

### DIFF
--- a/lava/lava-job-definitions/shared/macros.jinja2
+++ b/lava/lava-job-definitions/shared/macros.jinja2
@@ -39,6 +39,6 @@
     {% include "shared/tests/core-component.yaml" %}
 {% endmacro %}
 
-{% macro component_update(venv_name, component_name, payload_url, payload_testinfo_url, update_method, iteration="") %}
+{% macro component_update(venv_name, component_name, payload_url, payload_testinfo_url, update_method, soak_test="", iteration="") %}
     {% include "shared/tests/component-update.yaml" %}
 {% endmacro %}

--- a/lava/lava-job-definitions/shared/templates/component-update-job.yaml
+++ b/lava/lava-job-definitions/shared/templates/component-update-job.yaml
@@ -40,7 +40,7 @@
     definitions:
 
 
-    {{ macros.component_update(venv_name, component_name, payload_url, payload_testinfo_url, update_method, iteration) | indent }}
+    {{ macros.component_update(venv_name, component_name, payload_url, payload_testinfo_url, update_method, "--soak-test", iteration) | indent }}
 
     {{ macros.sleep(job_sleep, iteration) | indent }}
 

--- a/lava/lava-job-definitions/shared/tests/component-update.yaml
+++ b/lava/lava-job-definitions/shared/tests/component-update.yaml
@@ -13,3 +13,4 @@
     payload_url: "{{ payload_url }}"
     payload_testinfo_url: "{{ payload_testinfo_url }}"
     update_method: "{{ update_method }}"
+    soak_test: "{{ soak_test }}"


### PR DESCRIPTION
Change the component update template to allow a soak_test option to be
passedthrough to the pytest. This can then be used to disable certain
tests during the soak testing which would otherwice fail.