### PR TITLE
ci: Add clang-tidy checker.

### DIFF
--- a/ci/clang-tidy-check/Dockerfile
+++ b/ci/clang-tidy-check/Dockerfile
@@ -22,8 +22,9 @@ RUN apt-get install -y libsystemd-dev
 
 RUN rm -rf /var/lib/apt/lists/*
 
-# The build process needs working space to perform the build and
-# delivery the build products.
+# Create a work directory to copy the target dir into
 RUN mkdir -m 777 /work
-
-COPY clang-tidy-check.sh ./
+# CMake segfaults when run from the root directory, so put it in its own script dir
+RUN mkdir -m 777 /script
+COPY clang-tidy-check.sh /script/clang-tidy-check.sh
+WORKDIR /script

--- a/ci/clang-tidy-check/Dockerfile
+++ b/ci/clang-tidy-check/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright (c) 2020 Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+FROM ubuntu:bionic-20180724.1
+
+RUN apt-get update && apt-get install locales \
+    && dpkg-reconfigure locales \
+    && locale-gen en_US.UTF-8 \
+    && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+
+RUN apt-get update && apt-get install -y \
+    cmake \
+    make \
+    clang-tidy \
+    clang
+
+# Install project dependencies for mbl-core/updated
+RUN apt-get install -y libsystemd-dev
+
+RUN rm -rf /var/lib/apt/lists/*
+
+# The build process needs working space to perform the build and
+# delivery the build products.
+RUN mkdir -m 777 /work
+
+COPY clang-tidy-check.sh ./

--- a/ci/clang-tidy-check/README.md
+++ b/ci/clang-tidy-check/README.md
@@ -16,7 +16,7 @@ if(RUN_CODE_CHECKS)
 endif(RUN_CODE_CHECKS)
 ```
 
-The script checks for the presence of the above code and attempts to build the project if true.
+The `clang-tidy-check.sh` script checks for the presence of the above code and attempts to build the project if true.
 
 You must add any external dependencies for your project in the `Dockerfile`.
 Currently the `Dockerfile` only installs the dependencies for the UpdateD project in our `mbl-core` repository.
@@ -51,4 +51,3 @@ $ ./clang-tidy-check.sh --workdir /path/to/your/project
 ```
 
 Output will be printed on screen with the results.
-

--- a/ci/clang-tidy-check/README.md
+++ b/ci/clang-tidy-check/README.md
@@ -1,8 +1,8 @@
 # Clang tidy checker
 
-The `clang-tidy-check` builds a CMake project which has been configured to use clang-tidy.
+The `clang-tidy-check` builds a CMake project which has been configured to use `clang-tidy`.
 
-If any of the clang-tidy checks fail, the script will return a non-zero exit code.
+If any of the `clang-tidy` checks fail, the script will return a non-zero exit code.
 
 
 # Requirements
@@ -14,7 +14,6 @@ option(RUN_CODE_CHECKS OFF)
 if(RUN_CODE_CHECKS)
     set(CMAKE_CXX_CLANG_TIDY clang-tidy;-checks=*,-clang-analyzer-cplusplus-*,clang-analyzer-*)
 endif(RUN_CODE_CHECKS)
-
 ```
 
 The script checks for the presence of the above code and attempts to build the project if true.
@@ -22,12 +21,12 @@ The script checks for the presence of the above code and attempts to build the p
 You must add any external dependencies for your project in the `Dockerfile`.
 Currently the `Dockerfile` only installs the dependencies for the UpdateD project in our `mbl-core` repository.
 
-If you choose to run outside of docker, then you need to install cmake, clang, clang-tidy and any external dependencies.
+If you choose to run outside of docker, then you need to install `cmake`, `clang`, `clang-tidy` and any external dependencies.
 
-You must also provide a .clang-tidy file in the root of your project or repository, which specifies the WarningsAsErrors
+You must also provide a .clang-tidy file in the root of your project or repository, which specifies the `WarningsAsErrors`
 option for all enabled checks. See [our example in mbl-core](https://github.com/ARMmbed/mbl-core)
 
-Note: Our projects require CMake 3.5 or later and a version of clang that supports c++17.
+Note: Our projects require CMake 3.5 or later and a version of `clang` that supports c++17.
 
 # Usage
 
@@ -39,7 +38,7 @@ Invoke the `run-me.sh` script to run inside a docker container.
 $ ./run-me.sh --workdir /path/to/your/project
 ```
 
-This will create a container with the dependencies specified in the `Dockerfile` and run the clang-tidy checks.
+This will create a container with the dependencies specified in the `Dockerfile` and run the `clang-tidy` checks.
 
 Output will be printed on screen with the results.
 
@@ -47,9 +46,9 @@ Output will be printed on screen with the results.
 
 Invoke the `clang-tidy-checks.sh` script directly to run outside of a docker container.
 
-``
+```
 $ ./clang-tidy-check.sh --workdir /path/to/your/project
-``
+```
 
 Output will be printed on screen with the results.`
 

--- a/ci/clang-tidy-check/README.md
+++ b/ci/clang-tidy-check/README.md
@@ -1,0 +1,55 @@
+# Clang tidy checker
+
+The `clang-tidy-check` builds a CMake project which has been configured to use clang-tidy.
+
+If any of the clang-tidy checks fail, the script will return a non-zero exit code.
+
+
+# Requirements
+
+The CMake project in question must have the following lines in its `CMakeLists.txt`
+
+```
+option(RUN_CODE_CHECKS OFF)
+if(RUN_CODE_CHECKS)
+    set(CMAKE_CXX_CLANG_TIDY clang-tidy;-checks=*,-clang-analyzer-cplusplus-*,clang-analyzer-*)
+endif(RUN_CODE_CHECKS)
+
+```
+
+The script checks for the presence of the above code and attempts to build the project if true.
+
+You must add any external dependencies for your project in the `Dockerfile`.
+Currently the `Dockerfile` only installs the dependencies for the UpdateD project in our `mbl-core` repository.
+
+If you choose to run outside of docker, then you need to install cmake, clang, clang-tidy and any external dependencies.
+
+You must also provide a .clang-tidy file in the root of your project or repository, which specifies the WarningsAsErrors
+option for all enabled checks. See [our example in mbl-core](https://github.com/ARMmbed/mbl-core)
+
+Note: Our projects require CMake 3.5 or later and a version of clang that supports c++17.
+
+# Usage
+
+## Running with docker
+
+Invoke the `run-me.sh` script to run inside a docker container.
+
+```
+$ ./run-me.sh --workdir /path/to/your/project
+```
+
+This will create a container with the dependencies specified in the `Dockerfile` and run the clang-tidy checks.
+
+Output will be printed on screen with the results.
+
+## Running natively
+
+Invoke the `clang-tidy-checks.sh` script directly to run outside of a docker container.
+
+``
+$ ./clang-tidy-check.sh --workdir /path/to/your/project
+``
+
+Output will be printed on screen with the results.`
+

--- a/ci/clang-tidy-check/README.md
+++ b/ci/clang-tidy-check/README.md
@@ -2,7 +2,7 @@
 
 The `clang-tidy-check` builds a CMake project which has been configured to use `clang-tidy`.
 
-If any of the `clang-tidy` checks fail, the script will return a non-zero exit code.
+If any of the `clang-tidy` checks fail, the `clang-tidy-check.sh` script will return a non-zero exit code.
 
 
 # Requirements

--- a/ci/clang-tidy-check/README.md
+++ b/ci/clang-tidy-check/README.md
@@ -21,9 +21,9 @@ The script checks for the presence of the above code and attempts to build the p
 You must add any external dependencies for your project in the `Dockerfile`.
 Currently the `Dockerfile` only installs the dependencies for the UpdateD project in our `mbl-core` repository.
 
-If you choose to run outside of docker, then you need to install `cmake`, `clang`, `clang-tidy` and any external dependencies.
+If you choose to run outside of Docker, then you need to install `cmake`, `clang`, `clang-tidy` and any external dependencies.
 
-You must also provide a .clang-tidy file in the root of your project or repository, which specifies the `WarningsAsErrors`
+You must also provide a `.clang-tidy` file in the root of your project or repository, which specifies the `WarningsAsErrors`
 option for all enabled checks. See [our example in mbl-core](https://github.com/ARMmbed/mbl-core)
 
 Note: Our projects require CMake 3.5 or later and a version of `clang` that supports c++17.
@@ -50,5 +50,5 @@ Invoke the `clang-tidy-checks.sh` script directly to run outside of a docker con
 $ ./clang-tidy-check.sh --workdir /path/to/your/project
 ```
 
-Output will be printed on screen with the results.`
+Output will be printed on screen with the results.
 

--- a/ci/clang-tidy-check/clang-tidy-check.sh
+++ b/ci/clang-tidy-check/clang-tidy-check.sh
@@ -70,7 +70,7 @@ fi
 workdir=$(readlink -f "$workdir")
 
 CMAKE_PROJECTS=$(printf "%s" "$(find_cmake_projects)")
-if [ -z $CMAKE_PROJECTS ] ; then
+if [ -z "$CMAKE_PROJECTS" ]; then
     printf "No CMake projects configured for clang-tidy found. Exiting.\n"
     exit 1
 fi

--- a/ci/clang-tidy-check/clang-tidy-check.sh
+++ b/ci/clang-tidy-check/clang-tidy-check.sh
@@ -71,7 +71,7 @@ workdir=$(readlink -f "$workdir")
 
 CMAKE_PROJECTS=$(printf "%s" "$(find_cmake_projects)")
 if [ -z $CMAKE_PROJECTS ] ; then
-    printf "No CMake projects configured for clang-tidy found. Exiting."
+    printf "No CMake projects configured for clang-tidy found. Exiting.\n"
     exit 1
 fi
 

--- a/ci/clang-tidy-check/clang-tidy-check.sh
+++ b/ci/clang-tidy-check/clang-tidy-check.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+set -e
+set -u
+set -o pipefail
+
+rc=0
+
+usage()
+{
+  cat <<EOF
+
+usage: clang-tidy-check.sh [OPTION] -- [clang-tidy-check.sh arguments]
+
+  -h, --help            Print brief usage information and exit.
+  --workdir PATH        Specify the directory to check. Default PWD.
+  -x                    Enable shell debugging in this script.
+
+EOF
+}
+
+args=$(getopt -o+hx -l help,workdir: -n "$(basename "$0")" -- "$@")
+eval set -- "$args"
+while [ $# -gt 0 ]; do
+  if [ -n "${opt_prev:-}" ]; then
+    eval "$opt_prev=\$1"
+    opt_prev=
+    shift 1
+    continue
+  elif [ -n "${opt_append:-}" ]; then
+    eval "$opt_append=\"\${$opt_append:-} \$1\""
+    opt_append=
+    shift 1
+    continue
+  fi
+  case $1 in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+
+  --workdir)
+    opt_prev=workdir
+    ;;
+
+  -x)
+    set -x
+    ;;
+
+  --)
+    shift
+    break 2
+    ;;
+  esac
+  shift 1
+done
+
+if [ -z "${workdir:-}" ]; then
+  workdir="$(pwd)"
+fi
+
+workdir=$(readlink -f "$workdir")
+
+echo "Building project with clang-tidy checks enabled.\n"
+cmake "$workdir" "-DCMAKE_CXX_CLANG_TIDY=clang-tidy;-checks=*,-clang-analyzer-cplusplus*,clang-analyzer-*" \
+    -DCMAKE_CXX_COMPILER=clang \
+    -DCMAKE_INSTALL_LIBDIR=/usr/lib \
+    -DCMAKE_INSTALL_BINDIR=/usr/bin \
+    -B/tmp/ || rc=1
+
+make -C /tmp || rc=1
+
+exit $rc

--- a/ci/clang-tidy-check/clang-tidy-check.sh
+++ b/ci/clang-tidy-check/clang-tidy-check.sh
@@ -11,7 +11,7 @@ set -o pipefail
 rc=0
 
 find_cmake_projects() {
-    find $workdir -name CMakeLists.txt -print0 | xargs -0 --no-run-if-empty grep -l 'option(RUN_CODE_CHECKS OFF)' | xargs dirname
+    find "$workdir" -name CMakeLists.txt -print0 | xargs -0 --no-run-if-empty grep -l 'option(RUN_CODE_CHECKS OFF)' | xargs dirname
 }
 
 usage()
@@ -69,7 +69,7 @@ fi
 
 workdir=$(readlink -f "$workdir")
 
-CMAKE_PROJECTS=$(printf $(find_cmake_projects))
+CMAKE_PROJECTS=$(printf "%s" "$(find_cmake_projects)")
 
 for project in $CMAKE_PROJECTS; do
     printf "Building \"%s\" with clang-tidy checks enabled.\n" "$project"

--- a/ci/clang-tidy-check/clang-tidy-check.sh
+++ b/ci/clang-tidy-check/clang-tidy-check.sh
@@ -11,7 +11,7 @@ set -o pipefail
 rc=0
 
 find_cmake_projects() {
-    find "$workdir" -name CMakeLists.txt -print0 | xargs -0 --no-run-if-empty grep -l 'option(RUN_CODE_CHECKS OFF)' | xargs dirname
+    find "$workdir" -name CMakeLists.txt -print0 | xargs -0 --no-run-if-empty grep -l 'option(RUN_CODE_CHECKS ' | xargs --no-run-if-empty dirname
 }
 
 usage()
@@ -70,6 +70,10 @@ fi
 workdir=$(readlink -f "$workdir")
 
 CMAKE_PROJECTS=$(printf "%s" "$(find_cmake_projects)")
+if [ -z $CMAKE_PROJECTS ] ; then
+    printf "No CMake projects configured for clang-tidy found. Exiting."
+    exit 1
+fi
 
 for project in $CMAKE_PROJECTS; do
     printf "Building \"%s\" with clang-tidy checks enabled.\n" "$project"

--- a/ci/clang-tidy-check/run-me.sh
+++ b/ci/clang-tidy-check/run-me.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+set -e
+set -u
+
+execdir="$(readlink -e "$(dirname "$0")")"
+
+default_imagename="clang-tidy-check-env"
+default_containername="clang-tidy-check-container.$$"
+
+trap cleanup 0
+
+cleanup() {
+    # This command will return an id (eg. 43008e2a9f5a) of the running
+    # container
+    running_container="$(docker ps -q -f name="$default_containername")"
+    if [ ! -z "$running_container" ]; then
+        docker kill "$default_containername"
+    fi
+}
+
+usage()
+{
+  cat <<EOF
+
+usage: run-me.sh [OPTION] -- [run-me.sh arguments]
+
+  -h, --help            Print brief usage information and exit.
+  --image-name NAME     Specify the docker image name to build. Default ${default_imagename}.
+  --tty                 Enable tty creation (default).
+  --no-tty              Disable tty creation.
+  --workdir PATH        Specify the directory to check.  Default PWD.
+  -x                    Enable shell debugging in this script.
+
+EOF
+}
+
+imagename="$default_imagename"
+flag_tty="-t"
+
+args=$(getopt -o+hx -l help,image-name:,tty,no-tty,workdir: -n "$(basename "$0")" -- "$@")
+eval set -- "$args"
+while [ $# -gt 0 ]; do
+  if [ -n "${opt_prev:-}" ]; then
+    eval "$opt_prev=\$1"
+    opt_prev=
+    shift 1
+    continue
+  elif [ -n "${opt_append:-}" ]; then
+    eval "$opt_append=\"\${$opt_append:-} \$1\""
+    opt_append=
+    shift 1
+    continue
+  fi
+  case $1 in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+
+  --image-name)
+    opt_prev=imagename
+    ;;
+
+  --tty)
+    flag_tty="-t"
+    ;;
+
+  --no-tty)
+    flag_tty=
+    ;;
+
+  --workdir)
+    opt_prev=workdir
+    ;;
+
+  -x)
+    set -x
+    ;;
+
+  --)
+    shift
+    break 2
+    ;;
+  esac
+  shift 1
+done
+
+if [ -z "${workdir:-}" ]; then
+  workdir="$(pwd)"
+fi
+workdir=$(readlink -f "$workdir")
+
+docker build -t "$imagename" "$execdir"
+
+docker run --rm -i $flag_tty \
+       --name "$default_containername" \
+       -e LOCAL_UID="$(id -u)" -e LOCAL_GID="$(id -g)" \
+       -v "$workdir":/work "$imagename" \
+       ./clang-tidy-check.sh --workdir /work \
+       "$@"


### PR DESCRIPTION
We need a way to run static analysis on our C++ code.

This patch adds a set of shell scripts to perform clang-tidy checks on
CMake projects in a docker container.

Included:

* clang-tidy-check.sh: shell script to run clang-tidy from inside the
  container
* Dockerfile: the container specification, installs project dependencies
  for the mbl-core/updated project.
* run-me.sh: the entry point, runs the dockerr container and executes
  clang-tidy-check.sh

NOTE: These checks only work for the UpdateD project at the moment.
To run clang-tidy checks on other CMake projects, any library
dependencies need to be added to the ci/clang-tidy-check/Dockerfile.

**Jira**: IOTML-2664