### PR TITLE
ci:clang-tidy-check: Add UpdateD dependencies.

### DIFF
--- a/ci/clang-tidy-check/Dockerfile
+++ b/ci/clang-tidy-check/Dockerfile
@@ -2,59 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-FROM ubuntu:19.10
-
-RUN apt-get update && apt-get install locales \
-    && dpkg-reconfigure locales \
-    && locale-gen en_US.UTF-8 \
-    && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-
-# Add an apt repository containing the clang-9 packages.
-# We need clang-9 and its c++17 support for our C++ code.
-RUN apt-get install -y software-properties-common wget
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test
-RUN apt-get update && apt-get install -y \
-    git \
-    xz-utils \
-    build-essential \
-    autoconf \
-    libtool \
-    pkg-config \
-    libtinfo5 \
-    libncurses-dev \
-    curl \
-    cmake \
-    make \
-    clang-9 \
-    clang-tidy-9 \
-    g++ \
-    unzip
-
-# Install project dependencies for mbl-core/updated
-RUN apt-get install -y libsystemd-dev
-
-RUN rm -rf /var/lib/apt/lists/*
-
-# UpdateD requires protoc and gRPC, we need to build from source to get the gRPC
-# CPP runtime.
-# Configure protoc for the build.
-RUN git clone https://github.com/protocolbuffers/protobuf.git \
-    && cd protobuf \
-    && git submodule update --init --recursive \
-    && ./autogen.sh
-
-# Build and install protoc.
-RUN cd protobuf \
-    && ./configure \
-    && make && make check && make install \
-    && ldconfig
-
-# Build and install gRPC.
-RUN git clone -b v1.25.0 https://github.com/grpc/grpc \
-    && cd grpc \
-    && git submodule update --init \
-    && make && make install
+FROM rwalton00/mbl-sanity-checks:test
 
 # Create a work directory to copy the target dir into.
 RUN mkdir -m 777 /work

--- a/ci/clang-tidy-check/Dockerfile
+++ b/ci/clang-tidy-check/Dockerfile
@@ -2,29 +2,66 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-FROM ubuntu:bionic-20180724.1
+FROM ubuntu:19.10
 
 RUN apt-get update && apt-get install locales \
     && dpkg-reconfigure locales \
     && locale-gen en_US.UTF-8 \
     && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
-
 ENV LANG=en_US.UTF-8
 
+# Add an apt repository containing the clang-9 packages.
+# We need clang-9 and its c++17 support for our C++ code.
+RUN apt-get install -y software-properties-common wget
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN apt-get update && apt-get install -y \
+    git \
+    xz-utils \
+    build-essential \
+    autoconf \
+    libtool \
+    pkg-config \
+    libtinfo5 \
+    libncurses-dev \
+    curl \
     cmake \
     make \
-    clang-tidy \
-    clang
+    clang-9 \
+    clang-tidy-9 \
+    g++ \
+    unzip
 
 # Install project dependencies for mbl-core/updated
 RUN apt-get install -y libsystemd-dev
 
 RUN rm -rf /var/lib/apt/lists/*
 
-# Create a work directory to copy the target dir into
+# UpdateD requires protoc and gRPC, we need to build from source to get the gRPC
+# CPP runtime.
+# Configure protoc for the build.
+RUN git clone https://github.com/protocolbuffers/protobuf.git \
+    && cd protobuf \
+    && git submodule update --init --recursive \
+    && ./autogen.sh
+
+# Build and install protoc.
+RUN cd protobuf \
+    && ./configure \
+    && make && make check && make install \
+    && ldconfig
+
+# Build and install gRPC.
+RUN git clone -b v1.25.0 https://github.com/grpc/grpc \
+    && cd grpc \
+    && git submodule update --init \
+    && make && make install
+
+# Create a work directory to copy the target dir into.
 RUN mkdir -m 777 /work
-# CMake segfaults when run from the root directory, so put it in its own script dir
+
+# CMake segfaults when run from the root directory,
+# so put it in its own script dir.
 RUN mkdir -m 777 /script
+
 COPY clang-tidy-check.sh /script/clang-tidy-check.sh
 WORKDIR /script

--- a/ci/clang-tidy-check/clang-tidy-check.sh
+++ b/ci/clang-tidy-check/clang-tidy-check.sh
@@ -75,19 +75,24 @@ if [ -z "$CMAKE_PROJECTS" ]; then
     exit 1
 fi
 
+this_dir=$(pwd)
+
 for project in $CMAKE_PROJECTS; do
     printf "Building \"%s\" with clang-tidy checks enabled.\n" "$project"
     PROJECT_TMPDIR=/tmp/$(basename "$project")
-    mkdir -p "$PROJECT_TMPDIR"
-    cmake "$project" \
+    cp -r "$project" "$PROJECT_TMPDIR"
+    cd "$PROJECT_TMPDIR"
+    cmake . \
         --no-warn-unused-cli \
-        -B"$PROJECT_TMPDIR" \
         -DRUN_CODE_CHECKS=ON \
-        -DCMAKE_CXX_COMPILER=clang \
+        -DCMAKE_CXX_CLANG_TIDY=clang-tidy-9 \
+        -DCMAKE_CXX_COMPILER=clang++-9 \
+        -DCMAKE_C_COMPILER=clang-9 \
         -DCMAKE_INSTALL_LIBDIR=/usr/lib \
         -DCMAKE_INSTALL_BINDIR=/usr/bin \
-        -S"$project" || rc=1
-    make -C "$PROJECT_TMPDIR" || rc=1
+        || rc=1
+    make  || rc=1
+    cd "$this_dir"
 done
 
 exit $rc

--- a/ci/mbl-base-docker-image/Dockerfile
+++ b/ci/mbl-base-docker-image/Dockerfile
@@ -1,0 +1,57 @@
+# Copyright (c) 2020 Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+FROM ubuntu:19.10
+
+RUN apt-get update && apt-get install locales \
+    && dpkg-reconfigure locales \
+    && locale-gen en_US.UTF-8 \
+    && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+
+# Add an apt repository containing the clang-9 packages.
+# We need clang-9 and its c++17 support for our C++ code.
+RUN apt-get install -y software-properties-common wget
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN apt-get update && apt-get install -y \
+    git \
+    xz-utils \
+    build-essential \
+    autoconf \
+    libtool \
+    pkg-config \
+    libtinfo5 \
+    libncurses-dev \
+    curl \
+    cmake \
+    make \
+    clang-9 \
+    clang-tidy-9 \
+    g++ \
+    unzip
+
+# Install project dependencies for mbl-core/updated
+RUN apt-get install -y libsystemd-dev
+
+RUN rm -rf /var/lib/apt/lists/*
+
+# UpdateD requires protoc and gRPC, we need to build from source to get the gRPC
+# CPP runtime.
+# Configure protoc for the build.
+RUN git clone https://github.com/protocolbuffers/protobuf.git \
+    && cd protobuf \
+    && git submodule update --init --recursive \
+    && ./autogen.sh
+
+# Build and install protoc.
+RUN cd protobuf \
+    && ./configure \
+    && make && make check && make install \
+    && ldconfig
+
+# Build and install gRPC.
+RUN git clone -b v1.25.0 https://github.com/grpc/grpc \
+    && cd grpc \
+    && git submodule update --init \
+    && make && make install


### PR DESCRIPTION
UpdateD requires full C++17 support. This patch updates the build
toolchain in clang-tidy-check's docker container to support C++17.

UpdateD also depends on gRPC. We need to build gRPC from source to get
the C++ runtime. Add the fetch and build steps for gRPC and the protoc
compiler to the Dockerfile.

Out of tree builds were causing some issues with gRPC. So now we do an
in tree build, but we copy the CMake project to a sandboxed directory inside
the container before building it.